### PR TITLE
Fix emscripten background parallax FPS delay

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -255,7 +255,7 @@ else ifneq (,$(findstring armv,$(platform)))
 # emscripten
 else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_emscripten.bc
-	ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN
+	ENDIANNESS_DEFINES := -DLSB_FIRST -DALIGN_LONG -DHAVE_ALLOCA_H -DUSE_DYNAMIC_ALLOC -DUSE_MEMORY_H -DBYTE_ORDER=BIG_ENDIAN -DHAVE_ZLIB
 
 # Windows
 else


### PR DESCRIPTION
Build only on Emscripten 1.35.0 (clang 3.7) with LTO optimization !
On higher have version emscripten (clang 3.8 and 3.9) very baggy (video and controll glitch) !