### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -36,6 +36,10 @@ endif
 
 TARGET_NAME := genesis_plus_gx
 LIBM := -lm
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 # Unix
 ifeq ($(platform), unix)

--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 WANT_CRC32 := 1
 
 CORE_DIR := ../..

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1664,7 +1664,10 @@ void retro_set_input_state(retro_input_state_t cb) { input_state_cb = cb; }
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "Genesis Plus GX";
-   info->library_version = "v1.7.4";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version = "v1.7.4" GIT_VERSION;
    info->valid_extensions = "mdx|md|smd|gen|bin|cue|iso|sms|gg|sg";
    info->block_extract = false;
    info->need_fullpath = true;


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.