### PR TITLE
SMS mode memory fix

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2137,12 +2137,11 @@ void *retro_get_memory_data(unsigned id)
          return sram.sram;
       case RETRO_MEMORY_SYSTEM_RAM:
 
-	if (system_hw == SYSTEM_SMS){
-	  return zram; // 0x2000 = 8kb z80 ram
-	}else{
-	  return work_ram; //0x10000 = 64kb 68000 ram
-	}
-
+      if (system_hw == SYSTEM_SMS)
+	return zram; // 0x2000 = 8kb z80 ram
+      else
+	return work_ram; //0x10000 = 64kb 68000 ram
+	
       default:
          return NULL;
    }

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2140,7 +2140,7 @@ void *retro_get_memory_data(unsigned id)
 	if (system_hw == SYSTEM_SMS){
 	  return zram; // 0x2000 = 8kb z80 ram
 	}else{
-	  return work_ram; //0x10000 = 16kb 68000 ram
+	  return work_ram; //0x10000 = 64kb 68000 ram
 	}
 
       default:

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2136,7 +2136,12 @@ void *retro_get_memory_data(unsigned id)
       case RETRO_MEMORY_SAVE_RAM:
          return sram.sram;
       case RETRO_MEMORY_SYSTEM_RAM:
-         return work_ram;
+
+	if (system_hw == SYSTEM_SMS){
+	  return zram; // 0x2000 = 8kb z80 ram
+	}else{
+	  return work_ram; //0x10000 = 16kb 68000 ram
+	}
 
       default:
          return NULL;


### PR DESCRIPTION
Makes core return z80 ram when in SMS mode.

Implemented to allow cheevos system to work. Tested and confirmed working.