### PR TITLE
Fix crash loading chd file

### DIFF
--- a/core/cd_hw/libchdr/src/chd.c
+++ b/core/cd_hw/libchdr/src/chd.c
@@ -41,6 +41,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "types.h"
+#include "osd.h"
 #include "chd.h"
 #include "cdrom.h"
 #include "flac.h"


### PR DESCRIPTION
Ensure chd.c uses the libretro overrides of FILE and friends
since the emulator will really pass it an RFILE*.