### PR TITLE
Allow more fine-grained overclocking

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -441,7 +441,8 @@ LIBRETRO_CFLAGS += $(BPP_DEFINES) \
 		$(PLATFORM_DEFINES) \
 		-D__LIBRETRO__ \
 		-DM68K_ALLOW_OVERCLOCK \
-		-DZ80_ALLOW_OVERCLOCK
+		-DZ80_ALLOW_OVERCLOCK \
+		-DCYCLE_SHIFT=10
 
 ifneq (,$(findstring msvc,$(platform)))
    LIBRETRO_CFLAGS += -DINLINE="static _inline"

--- a/core/m68k/m68k.h
+++ b/core/m68k/m68k.h
@@ -269,7 +269,7 @@ typedef struct
   uint address_space;   /* Current FC code */
 
 #ifdef M68K_ALLOW_OVERCLOCK
-  uint8 overclock_ratio;
+  int cycle_ratio;
 #endif
 
   /* Callbacks to host */

--- a/core/m68k/m68kcpu.c
+++ b/core/m68k/m68kcpu.c
@@ -320,7 +320,7 @@ void m68k_init(void)
 #endif
 
 #ifdef M68K_ALLOW_OVERCLOCK
-  m68k.overclock_ratio = 1;
+  m68k.cycle_ratio = 1 << CYCLE_SHIFT;
 #endif
 
 #if M68K_EMULATE_INT_ACK == OPT_ON

--- a/core/m68k/m68kcpu.h
+++ b/core/m68k/m68kcpu.h
@@ -515,7 +515,7 @@
 /* ---------------------------- Cycle Counting ---------------------------- */
 
 #ifdef M68K_ALLOW_OVERCLOCK
-#define USE_CYCLES(A) m68ki_cpu.cycles += (A) / m68ki_cpu.overclock_ratio
+#define USE_CYCLES(A) m68ki_cpu.cycles += ((A) * m68ki_cpu.cycle_ratio) >> CYCLE_SHIFT
 #else
 #define USE_CYCLES(A) m68ki_cpu.cycles += (A)
 #endif

--- a/core/m68k/s68kcpu.c
+++ b/core/m68k/s68kcpu.c
@@ -285,7 +285,7 @@ void s68k_init(void)
 #endif
 
 #ifdef M68K_ALLOW_OVERCLOCK
-  s68k.overclock_ratio = 1;
+  s68k.cycle_ratio = 1 << CYCLE_SHIFT;
 #endif
 
 #if M68K_EMULATE_INT_ACK == OPT_ON

--- a/core/z80/z80.c
+++ b/core/z80/z80.c
@@ -202,7 +202,7 @@
 #define HALT Z80.halt
 
 #ifdef Z80_ALLOW_OVERCLOCK
-#define USE_CYCLES(A) Z80.cycles += (A) / z80_overclock_ratio
+#define USE_CYCLES(A) Z80.cycles += ((A) * z80_cycle_ratio) >> CYCLE_SHIFT
 #else
 #define USE_CYCLES(A) Z80.cycles += (A)
 #endif
@@ -210,7 +210,7 @@
 Z80_Regs Z80;
 
 #ifdef Z80_ALLOW_OVERCLOCK
-UINT8 z80_overclock_ratio;
+UINT32 z80_cycle_ratio;
 #endif
 
 unsigned char *z80_readmap[64];
@@ -3369,7 +3369,7 @@ void z80_init(const void *config, int (*irqcallback)(int))
   Z80.daisy = config;
   Z80.irq_callback = irqcallback;
 #ifdef Z80_ALLOW_OVERCLOCK
-  z80_overclock_ratio = 1;
+  z80_cycle_ratio = 1 << CYCLE_SHIFT;
 #endif
 
   /* Clear registers values (NB: should be random on real hardware ?) */

--- a/core/z80/z80.h
+++ b/core/z80/z80.h
@@ -52,7 +52,7 @@ typedef struct
 extern Z80_Regs Z80;
 
 #ifdef Z80_ALLOW_OVERCLOCK
-extern UINT8 z80_overclock_ratio;
+extern UINT32 z80_cycle_ratio;
 #endif
 
 extern unsigned char *z80_readmap[64];

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1257,10 +1257,17 @@ static void check_variables(void)
   var.key = "genesis_plus_gx_overclock";
   environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var);
   {
-    if (strcmp(var.value, "1x") == 0)
-      config.overclock = 0;
-    else if (strcmp(var.value, "2x") == 0)
-      config.overclock = 1;
+    /* Cycle ratios multiply cycle count, so use reciprocal */
+    if (strcmp(var.value, "100%") == 0)
+      config.overclock = (100 << CYCLE_SHIFT)/100;
+    else if (strcmp(var.value, "125%") == 0)
+      config.overclock = (100 << CYCLE_SHIFT)/125;
+    else if (strcmp(var.value, "150%") == 0)
+      config.overclock = (100 << CYCLE_SHIFT)/150;
+    else if (strcmp(var.value, "175%") == 0)
+      config.overclock = (100 << CYCLE_SHIFT)/175;
+    else if (strcmp(var.value, "200%") == 0)
+      config.overclock = (100 << CYCLE_SHIFT)/200;
   }
 #endif
 
@@ -1709,7 +1716,7 @@ void retro_set_environment(retro_environment_t cb)
       { "genesis_plus_gx_gun_cursor", "Show Lightgun crosshair; disabled|enabled" },
       { "genesis_plus_gx_invert_mouse", "Invert Mouse Y-axis; disabled|enabled" },
 #ifdef HAVE_OVERCLOCK
-      { "genesis_plus_gx_overclock", "Overclock CPU; 1x|2x" },
+      { "genesis_plus_gx_overclock", "CPU speed; 100%|125%|150%|175%|200%" },
 #endif
       { NULL, NULL },
    };
@@ -2360,30 +2367,30 @@ void retro_run(void)
    if (system_hw == SYSTEM_MCD)
    {
 #ifdef M68K_ALLOW_OVERCLOCK
-      if (config.overclock && overclock_delay == 0)
-         m68k.overclock_ratio = 2;
+      if (overclock_delay == 0)
+         m68k.cycle_ratio = config.overclock;
       else
-         m68k.overclock_ratio = 1;
+         m68k.cycle_ratio = 1 << CYCLE_SHIFT;
 #endif
       system_frame_scd(0);
    }
    else if ((system_hw & SYSTEM_PBC) == SYSTEM_MD)
    {
 #ifdef M68K_ALLOW_OVERCLOCK
-      if (config.overclock && overclock_delay == 0)
-         m68k.overclock_ratio = 2;
+      if (overclock_delay == 0)
+         m68k.cycle_ratio = config.overclock;
       else
-         m68k.overclock_ratio = 1;
+         m68k.cycle_ratio = 1 << CYCLE_SHIFT;
 #endif
       system_frame_gen(0);
    }
    else
    {
 #ifdef Z80_ALLOW_OVERCLOCK
-      if (config.overclock && overclock_delay == 0)
-         z80_overclock_ratio = 2;
+      if (overclock_delay == 0)
+         z80_cycle_ratio = config.overclock;
       else
-         z80_overclock_ratio = 1;
+         z80_cycle_ratio = 1 << CYCLE_SHIFT;
 #endif
       system_frame_sms(0);
    }

--- a/libretro/osd.h
+++ b/libretro/osd.h
@@ -120,7 +120,7 @@ struct
   t_input_config input[MAX_INPUTS];
   uint8 invert_mouse;
   uint8 gun_cursor;
-  uint8 overclock;
+  uint32 overclock;
 } config;
 
 extern char GG_ROM[256];


### PR DESCRIPTION
Some games can benefit from a little overclocking but start behaving
strangely at 2x.  Make the internal overclock ratio a fixed point
number and add 3 fractional settings.