### PR TITLE
Removed Audio Hard Disable, and excluded two more buffers when loading state.

### DIFF
--- a/core/cd_hw/pcm.c
+++ b/core/cd_hw/pcm.c
@@ -38,7 +38,6 @@
 #include "shared.h"
 
 extern int8 reset_do_not_clear_buffers;
-extern int8 audio_hard_disable;
 
 #define PCM_SCYCLES_RATIO (384 * 4)
 
@@ -125,8 +124,6 @@ void pcm_run(unsigned int length)
   /* previous audio outputs */
   int prev_l = pcm.out[0];
   int prev_r = pcm.out[1];
-
-  if (audio_hard_disable) return;
 
   /* check if PCM chip is running */
   if (pcm.enabled)

--- a/core/sound/psg.c
+++ b/core/sound/psg.c
@@ -43,8 +43,6 @@
 #include "shared.h"
 #include "blip_buf.h"
 
-extern int8 audio_hard_disable;
-
 /* internal clock = input clock : 16 = (master clock : 15) : 16 */
 #define PSG_MCYCLES_RATIO (15*16)
 
@@ -457,7 +455,6 @@ void psg_end_frame(unsigned int clocks)
 static void psg_update(unsigned int clocks)
 {
   int i, timestamp, polarity;
-  if (audio_hard_disable) return;
 
   for (i=0; i<4; i++)
   {

--- a/core/sound/ym2612.c
+++ b/core/sound/ym2612.c
@@ -146,8 +146,6 @@
 
 #include "shared.h"
 
-extern int8 audio_hard_disable;
-
 /* envelope generator */
 #define ENV_BITS    10
 #define ENV_LEN      (1<<ENV_BITS)
@@ -2006,7 +2004,6 @@ void YM2612Update(int *buffer, int length)
 {
   int i;
   int lt,rt;
-  if (audio_hard_disable) return;
 
   /* refresh PG increments and EG rates if required */
   refresh_fc_eg_chan(&ym2612.CH[0]);

--- a/core/system.c
+++ b/core/system.c
@@ -42,8 +42,6 @@
 #include "shared.h"
 #include "eq.h"
 
-extern int8 audio_hard_disable;
-
 /* Global variables */
 t_bitmap bitmap;
 t_snd snd;
@@ -196,8 +194,6 @@ int audio_update(int16 *buffer)
 {
   /* run sound chips until end of frame */
   int size = sound_update(mcycles_vdp);
-
-  if (audio_hard_disable) return 0;
 
   /* Mega CD specific */
   if (system_hw == SYSTEM_MCD)

--- a/core/vdp_ctrl.c
+++ b/core/vdp_ctrl.c
@@ -292,9 +292,12 @@ void vdp_reset(void)
 
   /* reset pattern cache changes */
   bg_list_index = 0;
-  memset ((char *) bg_name_dirty, 0, sizeof (bg_name_dirty));
-  memset ((char *) bg_name_list, 0, sizeof (bg_name_list));
-
+  if (!reset_do_not_clear_buffers)
+  {
+    /* Loadstate clears these */
+    memset((char *)bg_name_dirty, 0, sizeof(bg_name_dirty));
+    memset((char *)bg_name_list, 0, sizeof(bg_name_list));
+  }
   /* default Window clipping */
   window_clip(0,0);
 

--- a/core/vdp_render.c
+++ b/core/vdp_render.c
@@ -4087,10 +4087,8 @@ void render_reset(void)
 {
   if (!reset_do_not_clear_buffers)
   {
-#if 0
     /* Clear display bitmap */
     memset(bitmap.data, 0, bitmap.pitch * bitmap.height);
-#endif
 
     /* Clear line buffers */
     memset(linebuf, 0, sizeof(linebuf));

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2480,8 +2480,6 @@ void retro_reset(void)
    gen_reset(0);
 }
 
-extern int8 audio_hard_disable;
-
 void retro_run(void) 
 {
    bool okay = false;
@@ -2503,12 +2501,10 @@ void retro_run(void)
       bool videoEnabled = 0 != (result & 1);
       bool hardDisableAudio = 0 != (result & 8);
       do_skip = !videoEnabled;
-      audio_hard_disable = hardDisableAudio;
    }
    else
    {
       do_skip = false;
-      audio_hard_disable = false;
    }
 
    if (system_hw == SYSTEM_MCD)


### PR DESCRIPTION
Removed Audio Hard Disable entirely due to people encountering crashes.  I might reinstate the feature if I can get it working without any crashes.
Excluded two more buffers from being cleared when loading state.