### PR TITLE
Savestate speedups and audio fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sdl/gen_sdl2
 sdl/build_sdl
 sdl/build_sdl2
 
+/libretro/msvc/msvc-2017/msvc-2017.vcxproj.user

--- a/core/cart_hw/md_cart.c
+++ b/core/cart_hw/md_cart.c
@@ -760,10 +760,15 @@ int md_cart_context_save(uint8 *state)
       /* SRAM */
       state[bufferptr++] = 0xff;
     }
-    else
+    else if (base >= cart.rom && base < cart.rom + MAXROMSIZE)
     {
       /* ROM */
       state[bufferptr++] = ((base - cart.rom) >> 16) & 0xff;
+    }
+    else
+    {
+      /* TMSS or special cartridge rom */
+      state[bufferptr++] = 0xfe;
     }
   }
 
@@ -805,7 +810,7 @@ int md_cart_context_load(uint8 *state)
       zbank_memory_map[i].write   = sram_write_byte;
 
     }
-    else
+    else if (offset < (MAXROMSIZE >> 16))
     {
       /* check if SRAM was mapped there before loading state */
       if (m68k.memory_map[i].base == sram.sram)
@@ -820,6 +825,10 @@ int md_cart_context_load(uint8 *state)
 
       /* ROM */
       m68k.memory_map[i].base = cart.rom + (offset << 16);
+    }
+    else
+    {
+      /* TMSS or Special cartridge ROM mapped in by reset, leave it mapped */
     }
   }
 

--- a/core/cd_hw/cdd.c
+++ b/core/cd_hw/cdd.c
@@ -37,6 +37,11 @@
  ****************************************************************************************/
 #include "shared.h"
 
+static int cdd_get_audio_sample_difference(void);
+static int cdd_get_audio_sample_offset_lba(void);
+
+extern int8 audio_hard_disable;
+
 #if defined(USE_LIBTREMOR) || defined(USE_LIBVORBIS)
 #define SUPPORTED_EXT 20
 #else
@@ -223,10 +228,22 @@ void cdd_reset(void)
 int cdd_context_save(uint8 *state)
 {
   int bufferptr = 0;
+  int audioSampleDifference = 0;
+  int indexValue = 0;
 
   save_param(&cdd.cycles, sizeof(cdd.cycles));
   save_param(&cdd.latency, sizeof(cdd.latency));
-  save_param(&cdd.index, sizeof(cdd.index));
+
+  /* If we are in an audio track, record the difference between LBA audio position and actual audio position */
+  if (cdd.toc.tracks[cdd.index].type == 0)
+  {
+    audioSampleDifference = cdd_get_audio_sample_difference();
+  }
+
+  /* Pack index (CD track number 0-99, now lower 8 bits) and difference between audioSampleOffset and LBA audio position (24-bit signed) into the 32-bit Index Value */
+  indexValue = (cdd.index & 0xFF) | (audioSampleDifference << 8);
+  save_param(&indexValue, sizeof(indexValue));
+
   save_param(&cdd.lba, sizeof(cdd.lba));
   save_param(&cdd.scanOffset, sizeof(cdd.scanOffset));
   save_param(&cdd.volume, sizeof(cdd.volume));
@@ -239,6 +256,8 @@ int cdd_context_load(uint8 *state)
 {
   int lba;
   int bufferptr = 0;
+  int audioSampleDifference = 0;
+  int indexValue = 0;
 
 #if defined(USE_LIBTREMOR) || defined(USE_LIBVORBIS)
 #ifdef DISABLE_MANY_OGG_OPEN_FILES
@@ -252,7 +271,15 @@ int cdd_context_load(uint8 *state)
 
   load_param(&cdd.cycles, sizeof(cdd.cycles));
   load_param(&cdd.latency, sizeof(cdd.latency));
-  load_param(&cdd.index, sizeof(cdd.index));
+  load_param(&indexValue, sizeof(indexValue));
+  /* unpack 32-bit Index value into Index (track number, lower 8 bits) and difference between actual sample position and LBA sample position (higher 24 bits) */
+  cdd.index = indexValue & 0xFF;
+  audioSampleDifference = indexValue >> 8;
+  /* force sign extension */
+  if (indexValue < 0)
+  {
+    audioSampleDifference |= 0xFF000000;
+  }
   load_param(&cdd.lba, sizeof(cdd.lba));
   load_param(&cdd.scanOffset, sizeof(cdd.scanOffset));
   load_param(&cdd.volume, sizeof(cdd.volume));
@@ -278,6 +305,16 @@ int cdd_context_load(uint8 *state)
   {
     /* CHD file offset */
     cdd.chd.hunkofs = cdd.toc.tracks[cdd.index].offset + (lba * CD_FRAME_SIZE);
+    /* For a CD audio track, seek to the saved audio sample position */
+    if (cdd.toc.tracks[cdd.index].type == 0)
+    {
+      int sectorNumber;
+      int offsetWithinSector;
+      cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba() + audioSampleDifference;
+      sectorNumber = (cdd.audioSampleOffset * 4) / CD_MAX_SECTOR_DATA;
+      offsetWithinSector = (cdd.audioSampleOffset * 4) - sectorNumber * CD_MAX_SECTOR_DATA;
+      cdd.chd.hunkofs = cdd.toc.tracks[cdd.index].offset + ((cdd.toc.tracks[cdd.index].start + sectorNumber) * CD_FRAME_SIZE) + offsetWithinSector;
+    }
   }
   else
 #endif
@@ -289,18 +326,26 @@ int cdd_context_load(uint8 *state)
 #if defined(USE_LIBTREMOR) || defined(USE_LIBVORBIS)
   else if (cdd.toc.tracks[cdd.index].vf.seekable)
   {
+    int trackOffset = cdd.toc.tracks[cdd.index].offset;
+    cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba() + audioSampleDifference;
 #ifdef DISABLE_MANY_OGG_OPEN_FILES
     /* VORBIS file need to be opened first */
     ov_open_callbacks(cdd.toc.tracks[cdd.index].fd,&cdd.toc.tracks[cdd.index].vf,0,0,cb);
 #endif
     /* VORBIS AUDIO track */
-    ov_pcm_seek(&cdd.toc.tracks[cdd.index].vf, (lba * 588) - cdd.toc.tracks[cdd.index].offset);
+    ov_pcm_seek(&cdd.toc.tracks[cdd.index].vf, (lba * 588) - trackOffset + audioSampleDifference);
   }
 #endif
   else if (cdd.toc.tracks[cdd.index].fd)
   {
     /* PCM AUDIO track */
-    cdStreamSeek(cdd.toc.tracks[cdd.index].fd, (lba * 2352) - cdd.toc.tracks[cdd.index].offset, SEEK_SET);
+    const int SECTOR_SIZE = 2352;
+    int trackStart = cdd.toc.tracks[cdd.index].start;
+    int trackOffset = cdd.toc.tracks[cdd.index].offset;
+    int seekAddress;
+    cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba() + audioSampleDifference;
+    seekAddress = trackStart * SECTOR_SIZE + cdd.audioSampleOffset * 4 - trackOffset;
+    cdStreamSeek(cdd.toc.tracks[cdd.index].fd, seekAddress, SEEK_SET);
   }
 
   return bufferptr;
@@ -1288,6 +1333,13 @@ void cdd_read_audio(unsigned int samples)
     /* CD-DA fader volume setup (0-1024) */
     int endVol = scd.regs[0x34>>1].w >> 4;
 
+    cdd.audioSampleOffset += samples;
+
+    if (audio_hard_disable)
+    {
+      return;
+    }
+    
     /* read samples from current block */
 #if defined(USE_LIBCHDR)
     if (cdd.chd.file)
@@ -1635,6 +1687,7 @@ void cdd_update(void)
       {
         /* CHD file offset */
         cdd.chd.hunkofs = cdd.toc.tracks[cdd.index].offset + (cdd.toc.tracks[cdd.index].start * CD_FRAME_SIZE);
+        cdd.audioSampleOffset = 0;
       }
       else
 #endif
@@ -1646,12 +1699,14 @@ void cdd_update(void)
         ov_open_callbacks(cdd.toc.tracks[cdd.index].fd,&cdd.toc.tracks[cdd.index].vf,0,0,cb);
 #endif
         ov_pcm_seek(&cdd.toc.tracks[cdd.index].vf, (cdd.toc.tracks[cdd.index].start * 588) - cdd.toc.tracks[cdd.index].offset);
+        cdd.audioSampleOffset = 0;
       }
       else
 #endif 
       if (cdd.toc.tracks[cdd.index].fd)
       {
         cdStreamSeek(cdd.toc.tracks[cdd.index].fd, (cdd.toc.tracks[cdd.index].start * 2352) - cdd.toc.tracks[cdd.index].offset, SEEK_SET);
+        cdd.audioSampleOffset = 0;
       }
     }
   }
@@ -1738,6 +1793,7 @@ void cdd_update(void)
     {
       /* CHD file offset */
       cdd.chd.hunkofs = cdd.toc.tracks[cdd.index].offset + (cdd.lba * CD_FRAME_SIZE);
+      if (cdd.toc.tracks[cdd.index].type == 0) cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba();
     }
     else
 #endif
@@ -1759,12 +1815,14 @@ void cdd_update(void)
 #endif
       /* VORBIS AUDIO track */
       ov_pcm_seek(&cdd.toc.tracks[cdd.index].vf, (cdd.lba * 588) - cdd.toc.tracks[cdd.index].offset);
+      cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba();
     }
 #endif 
     else if (cdd.toc.tracks[cdd.index].fd)
     {
       /* PCM AUDIO track */
       cdStreamSeek(cdd.toc.tracks[cdd.index].fd, (cdd.lba * 2352) - cdd.toc.tracks[cdd.index].offset, SEEK_SET);
+      cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba();
     }
   }
 }
@@ -1968,6 +2026,7 @@ void cdd_process(void)
       {
         /* CHD file offset */
         cdd.chd.hunkofs = cdd.toc.tracks[cdd.index].offset + (lba * CD_FRAME_SIZE);
+        if (cdd.toc.tracks[cdd.index].type == 0) cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba();
       }
       else
 #endif
@@ -1981,12 +2040,14 @@ void cdd_process(void)
       {
         /* VORBIS AUDIO track */
         ov_pcm_seek(&cdd.toc.tracks[index].vf, (lba * 588) - cdd.toc.tracks[index].offset);
+        cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba();
       }
 #endif 
       else if (cdd.toc.tracks[index].fd)
       {
         /* PCM AUDIO track */
         cdStreamSeek(cdd.toc.tracks[index].fd, (lba * 2352) - cdd.toc.tracks[index].offset, SEEK_SET);
+        cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba();
       }
 
       /* seek to current subcode position */
@@ -2074,6 +2135,7 @@ void cdd_process(void)
       {
         /* CHD file offset */
         cdd.chd.hunkofs = cdd.toc.tracks[cdd.index].offset + (lba * CD_FRAME_SIZE);
+        if (cdd.toc.tracks[cdd.index].type == 0) cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba();
       }
       else
 #endif
@@ -2087,12 +2149,14 @@ void cdd_process(void)
       {
         /* VORBIS AUDIO track */
         ov_pcm_seek(&cdd.toc.tracks[index].vf, (lba * 588) - cdd.toc.tracks[index].offset);
+        cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba();
       }
 #endif 
       else if (cdd.toc.tracks[index].fd)
       {
         /* PCM AUDIO track */
         cdStreamSeek(cdd.toc.tracks[index].fd, (lba * 2352) - cdd.toc.tracks[index].offset, SEEK_SET);
+        cdd.audioSampleOffset = cdd_get_audio_sample_offset_lba();
       }
 
       /* seek to current subcode position */
@@ -2223,4 +2287,16 @@ void cdd_process(void)
                                scd.regs[0x3c>>1].byte.h + scd.regs[0x3c>>1].byte.l +
                                scd.regs[0x3e>>1].byte.h + scd.regs[0x3e>>1].byte.l +
                                scd.regs[0x40>>1].byte.h) & 0x0f;
+}
+
+static int cdd_get_audio_sample_offset_lba(void)
+{
+  const int SECTOR_SIZE = 2352;
+  int trackStart = cdd.toc.tracks[cdd.index].start;
+  return (cdd.lba - trackStart) * SECTOR_SIZE / 4;
+}
+
+static int cdd_get_audio_sample_difference(void)
+{
+  return cdd.audioSampleOffset - cdd_get_audio_sample_offset_lba();
 }

--- a/core/cd_hw/cdd.c
+++ b/core/cd_hw/cdd.c
@@ -1337,6 +1337,33 @@ void cdd_read_audio(unsigned int samples)
 
     if (audio_hard_disable)
     {
+      if (endVol > curVol)
+      {
+        if (endVol - curVol < samples)
+        {
+          curVol = endVol;
+        }
+        else
+        {
+          curVol += samples;
+        }
+      }
+      else if (curVol > endVol)
+      {
+        if (curVol - endVol < samples)
+        {
+          curVol = endVol;
+        }
+        else
+        {
+          curVol -= samples;
+        }
+      }
+
+      /* save current CD-DA fader volume */
+      cdd.volume = curVol;
+
+      blip_end_frame(snd.blips[2], samples);
       return;
     }
     

--- a/core/cd_hw/cdd.h
+++ b/core/cd_hw/cdd.h
@@ -115,6 +115,7 @@ typedef struct
   chd_t chd;
 #endif
   int16 audio[2];
+  int audioSampleOffset;
 } cdd_t; 
 
 /* Function prototypes */

--- a/core/cd_hw/pcm.c
+++ b/core/cd_hw/pcm.c
@@ -153,6 +153,9 @@ static void pcm_run_silent(unsigned int length)
     }
   }
 #endif
+  /* end of blip buffer frame */
+  blip_end_frame(snd.blips[1], length);
+
   pcm.cycles += length * PCM_SCYCLES_RATIO;
 }
 

--- a/core/cd_hw/pcm.c
+++ b/core/cd_hw/pcm.c
@@ -37,6 +37,9 @@
  ****************************************************************************************/
 #include "shared.h"
 
+extern int8 audio_hard_disable;
+#define SILENT_RUN_PCM_ADDRESS
+
 extern int8 reset_do_not_clear_buffers;
 
 #define PCM_SCYCLES_RATIO (384 * 4)
@@ -115,6 +118,44 @@ int pcm_context_load(uint8 *state)
   return bufferptr;
 }
 
+static void pcm_run_silent(unsigned int length)
+{
+#ifdef SILENT_RUN_PCM_ADDRESS
+  /* Silent Version - Only updates sample address */
+  if (pcm.enabled)
+  {
+    int i, j;
+
+    /* run eight PCM channels */
+    for (j = 0; j<8; j++)
+    {
+      /* check if channel is enabled and increment is greater than zero */
+      if (pcm.status & (1 << j) && pcm.chan[j].fd.w > 0)
+      {
+        for (i = 0; i<length; i++)
+        {
+          /* read from current WAVE RAM address */
+          short data = pcm.ram[(pcm.chan[j].addr >> 11) & 0xffff];
+
+          /* loop data ? */
+          if (data == 0xff)
+          {
+            /* reset WAVE RAM address */
+            pcm.chan[j].addr = pcm.chan[j].ls.w << 11;
+          }
+          else
+          {
+            /* increment WAVE RAM address */
+            pcm.chan[j].addr += pcm.chan[j].fd.w;
+          }
+        }
+      }
+    }
+  }
+#endif
+  pcm.cycles += length * PCM_SCYCLES_RATIO;
+}
+
 void pcm_run(unsigned int length)
 {
 #ifdef LOG_PCM
@@ -124,6 +165,12 @@ void pcm_run(unsigned int length)
   /* previous audio outputs */
   int prev_l = pcm.out[0];
   int prev_r = pcm.out[1];
+
+  if (audio_hard_disable)
+  {
+    pcm_run_silent(length);
+    return;
+  }
 
   /* check if PCM chip is running */
   if (pcm.enabled)

--- a/core/genesis.c
+++ b/core/genesis.c
@@ -323,6 +323,7 @@ void gen_reset(int hard_reset)
       {
         /* save default cartridge slot mapping */
         cart.base = m68k.memory_map[0].base;
+        if (cart.base == boot_rom) cart.base = &cart.rom[0];
 
         /* BOOT ROM is mapped at $000000-$0007FF */
         m68k.memory_map[0].base = boot_rom;

--- a/core/sound/blip_buf.c
+++ b/core/sound/blip_buf.c
@@ -279,6 +279,14 @@ static void remove_samples( blip_t* m, int count )
 #endif
 }
 
+int blip_discard_samples_dirty(blip_t* m, int count)
+{
+	if (count > (m->offset >> time_bits))
+		count = m->offset >> time_bits;
+
+	m->offset -= count * time_unit;
+}
+
 int blip_read_samples( blip_t* m, short out [], int count)
 {
 #ifdef BLIP_ASSERT

--- a/core/sound/blip_buf.c
+++ b/core/sound/blip_buf.c
@@ -84,6 +84,20 @@ struct blip_t
 #endif
 };
 
+#define BLIP_BUFFER_STATE_BUFFER_SIZE 16
+
+typedef struct blip_buffer_state_t
+{
+	fixed_t offset;
+#ifdef BLIP_MONO
+	int integrator;
+	buf_t buffer[BLIP_BUFFER_STATE_BUFFER_SIZE];
+#else
+	int integrator[2];
+	buf_t buffer[2][BLIP_BUFFER_STATE_BUFFER_SIZE];
+#endif
+};
+
 #ifdef BLIP_MONO
 /* probably not totally portable */
 #define SAMPLES( blip ) ((buf_t*) ((blip) + 1))
@@ -684,3 +698,59 @@ void blip_add_delta_fast( blip_t* m, unsigned time, int delta )
 	out [8] += delta2;
 }
 #endif
+
+void blip_save_buffer_state(const blip_t *buf, blip_buffer_state_t *state)
+{
+#ifdef BLIP_MONO
+	state->integrator = buf->integrator;
+	if (buf->buffer && buf->size >= BLIPSTATE_BUFFER_SIZE)
+	{
+		memcpy(state->buffer, buf->buffer, sizeof(state->buffer));
+	}
+#else
+	int c;
+	for (c = 0; c < 2; c++)
+	{
+		state->integrator[c] = buf->integrator[c];
+		if (buf->buffer[c] && buf->size >= BLIP_BUFFER_STATE_BUFFER_SIZE)
+		{
+			memcpy(state->buffer[c], buf->buffer[c], sizeof(state->buffer[c]));
+		}
+	}
+#endif
+	state->offset = buf->offset;
+}
+
+void blip_load_buffer_state(blip_t *buf, const blip_buffer_state_t *state)
+{
+#ifdef BLIP_MONO
+	state->integrator = buf->integrator;
+	if (buf->buffer && buf->size >= BLIPSTATE_BUFFER_SIZE)
+	{
+		memcpy(state->buffer, buf->buffer, sizeof(state->buffer));
+	}
+#else
+	int c;
+	for (c = 0; c < 2; c++)
+	{
+		buf->integrator[c] = state->integrator[c];
+		if (buf->buffer[c] && buf->size >= BLIP_BUFFER_STATE_BUFFER_SIZE)
+		{
+			memcpy(buf->buffer[c], state->buffer[c], sizeof(state->buffer[c]));
+		}
+	}
+#endif
+	buf->offset = (fixed_t)state->offset;
+}
+
+blip_buffer_state_t* blip_new_buffer_state()
+{
+	return (blip_buffer_state_t*)calloc(1, sizeof(blip_buffer_state_t));
+}
+
+void blip_delete_buffer_state(blip_buffer_state_t *state)
+{
+	if (state == NULL) return;
+	memset(state, 0, sizeof(blip_buffer_state_t));
+	free(state);
+}

--- a/core/sound/blip_buf.h
+++ b/core/sound/blip_buf.h
@@ -64,6 +64,10 @@ void blip_end_frame( blip_t*, unsigned clock_duration );
 /** Number of buffered samples available for reading. */
 int blip_samples_avail( const blip_t* );
 
+/** Discards samples by moving the write pointer backwards directly,
+leaving the audio buffer dirty. */
+int blip_discard_samples_dirty(blip_t*, int count);
+
 /** Reads and removes at most 'count' samples and writes them to to every other 
 element of 'out', allowing easy interleaving of two buffers into a stereo sample
 stream. Outputs 16-bit signed samples. Returns number of samples actually read.  */

--- a/core/sound/blip_buf.h
+++ b/core/sound/blip_buf.h
@@ -11,6 +11,7 @@
 /** First parameter of most functions is blip_t*, or const blip_t* if nothing
 is changed. */
 typedef struct blip_t blip_t;
+typedef struct blip_buffer_state_t blip_buffer_state_t;
 
 /** Creates new buffer that can hold at most sample_count samples. Sets rates
 so that there are blip_max_ratio clocks per sample. Returns pointer to new
@@ -34,15 +35,15 @@ void blip_clear( blip_t* );
 void blip_add_delta( blip_t*, unsigned time, int delta_l, int delta_r );
 
 /** Same as blip_add_delta(), but uses faster, lower-quality synthesis. */
-void blip_add_delta_fast( blip_t*, unsigned int clock_time, int delta_l, int delta_r );
+void blip_add_delta_fast( blip_t*, unsigned time, int delta_l, int delta_r );
 
 #else
 
 /** Adds positive/negative delta into buffer at specified clock time. */
-void blip_add_delta( blip_t*, unsigned int clock_time, int delta );
+void blip_add_delta( blip_t*, unsigned clock_time, int delta );
 
 /** Same as blip_add_delta(), but uses faster, lower-quality synthesis. */
-void blip_add_delta_fast( blip_t*, unsigned int clock_time, int delta );
+void blip_add_delta_fast( blip_t*, unsigned clock_time, int delta );
 
 #endif
 
@@ -58,7 +59,7 @@ samples. Also begins new time frame at clock_duration, so that clock time 0 in
 the new time frame specifies the same clock as clock_duration in the old time
 frame specified. Deltas can have been added slightly past clock_duration (up to
 however many clocks there are in two output samples). */
-void blip_end_frame( blip_t*, unsigned int clock_duration );
+void blip_end_frame( blip_t*, unsigned clock_duration );
 
 /** Number of buffered samples available for reading. */
 int blip_samples_avail( const blip_t* );
@@ -74,6 +75,18 @@ int blip_mix_samples( blip_t* m1, blip_t* m2, blip_t* m3, short out [], int coun
 /** Frees buffer. No effect if NULL is passed. */
 void blip_delete( blip_t* );
 
+/** Saves buffer state (samples, accumulators, and offset) to a blip_buffer_state structure */
+void blip_save_buffer_state(const blip_t *buf, blip_buffer_state_t *state);
+
+/** Restores buffer state (samples, accumulators, and offset) from a blip_buffer_state structure */
+void blip_load_buffer_state(blip_t *buf, const blip_buffer_state_t *state);
+
+/** Creates new blip_buffer_state. Returns pointer to new buffer,
+or NULL if insufficient memory. */
+blip_buffer_state_t* blip_new_buffer_state();
+
+/** Frees blip_buffer_state. No effect if NULL is passed. */
+void blip_delete_buffer_state(blip_buffer_state_t *state);
 
 /* Deprecated */
 typedef blip_t blip_buffer_t;

--- a/core/sound/psg.c
+++ b/core/sound/psg.c
@@ -43,6 +43,8 @@
 #include "shared.h"
 #include "blip_buf.h"
 
+extern int8 audio_hard_disable;
+
 /* internal clock = input clock : 16 = (master clock : 15) : 16 */
 #define PSG_MCYCLES_RATIO (15*16)
 
@@ -455,6 +457,7 @@ void psg_end_frame(unsigned int clocks)
 static void psg_update(unsigned int clocks)
 {
   int i, timestamp, polarity;
+  if (audio_hard_disable) return;
 
   for (i=0; i<4; i++)
   {

--- a/core/sound/sound.c
+++ b/core/sound/sound.c
@@ -40,6 +40,8 @@
 #include "shared.h"
 #include "blip_buf.h"
 
+int8 audio_hard_disable = 0;
+
 /* YM2612 internal clock = input clock / 6 = (master clock / 7) / 6 */
 #define YM2612_CLOCK_RATIO (7*6)
 
@@ -218,6 +220,71 @@ static unsigned int YM3438_Read(unsigned int cycles, unsigned int a)
 }
 #endif
 
+static void NULL_YM_Update(int *buffer, int length)
+{
+
+}
+
+void NULL_fm_reset(unsigned int cycles)
+{
+
+}
+
+void NULL_fm_write(unsigned int cycles, unsigned int address, unsigned int data)
+{
+
+}
+
+unsigned int NULL_fm_read(unsigned int cycles, unsigned int address)
+{
+  return 0;
+}
+
+void sound_update_fm_function_pointers(void)
+{
+  /* Only set function pointers for YM_Update, fm_reset, fm_write, fm_read */
+  if (audio_hard_disable)
+  {
+    /* Dummy audio callbacks for audio hard disable */
+    YM_Update = NULL_YM_Update;
+    fm_reset = NULL_fm_reset;
+    fm_write = NULL_fm_write;
+    fm_read = NULL_fm_read;
+    return;
+  }
+
+  if ((system_hw & SYSTEM_PBC) == SYSTEM_MD)
+  {
+    /* YM2612 */
+#ifdef HAVE_YM3438_CORE
+    if (config.ym3438)
+    {
+      /* Nuked OPN2 */
+      YM_Update = YM3438_Update;
+      fm_reset = YM3438_Reset;
+      fm_write = YM3438_Write;
+      fm_read = YM3438_Read;
+    }
+    else
+#endif
+    {
+      /* MAME OPN2 */
+      YM_Update = YM2612Update;
+      fm_reset = YM2612_Reset;
+      fm_write = YM2612_Write;
+      fm_read = YM2612_Read;
+    }
+  }
+  else
+  {
+    /* YM2413 */
+    YM_Update = (config.ym2413 & 1) ? YM2413Update : NULL;
+    fm_reset = YM2413_Reset;
+    fm_write = YM2413_Write;
+    fm_read = NULL;
+  }
+}
+
 void sound_init( void )
 {
   /* Initialize FM chip */
@@ -242,7 +309,7 @@ void sound_init( void )
     else
 #endif
     {
-      /* MAME OPN2*/
+      /* MAME OPN2 */
       YM2612Init();
       YM2612Config(config.ym2612);
       YM_Update = YM2612Update;
@@ -269,6 +336,16 @@ void sound_init( void )
 
   /* Initialize PSG chip */
   psg_init((system_hw == SYSTEM_SG) ? PSG_DISCRETE : PSG_INTEGRATED);
+
+  if (audio_hard_disable)
+  {
+    /* Dummy audio callbacks for audio hard disable */
+    YM_Update = NULL_YM_Update;
+    fm_reset = NULL_fm_reset;
+    fm_write = NULL_fm_write;
+    fm_read = NULL_fm_read;
+    return;
+  }
 }
 
 void sound_reset(void)
@@ -314,40 +391,45 @@ int sound_update(unsigned int cycles)
     /* FM buffer start pointer */
     ptr = fm_buffer;
 
-    /* flush FM samples */
-    if (config.hq_fm)
+    if (!audio_hard_disable)
     {
-      /* high-quality Band-Limited synthesis */
-      do
+      /* flush FM samples */
+      if (config.hq_fm)
       {
-        /* left & right channels */
-        l = ((*ptr++ * preamp) / 100);
-        r = ((*ptr++ * preamp) / 100);
-        blip_add_delta(snd.blips[0], time, l-prev_l, r-prev_r);
-        prev_l = l;
-        prev_r = r;
+        /* high-quality Band-Limited synthesis */
+        do
+        {
+          /* left & right channels */
+          l = ((*ptr++ * preamp) / 100);
+          r = ((*ptr++ * preamp) / 100);
+          blip_add_delta(snd.blips[0], time, l - prev_l, r - prev_r);
+          prev_l = l;
+          prev_r = r;
 
-        /* increment time counter */
-        time += fm_cycles_ratio;
+          /* increment time counter */
+          time += fm_cycles_ratio;
+        } while (time < cycles);
       }
-      while (time < cycles);
+      else
+      {
+        /* faster Linear Interpolation */
+        do
+        {
+          /* left & right channels */
+          l = ((*ptr++ * preamp) / 100);
+          r = ((*ptr++ * preamp) / 100);
+          blip_add_delta_fast(snd.blips[0], time, l - prev_l, r - prev_r);
+          prev_l = l;
+          prev_r = r;
+
+          /* increment time counter */
+          time += fm_cycles_ratio;
+        } while (time < cycles);
+      }
     }
     else
     {
-      /* faster Linear Interpolation */
-      do
-      {
-        /* left & right channels */
-        l = ((*ptr++ * preamp) / 100);
-        r = ((*ptr++ * preamp) / 100);
-        blip_add_delta_fast(snd.blips[0], time, l-prev_l, r-prev_r);
-        prev_l = l;
-        prev_r = r;
-
-        /* increment time counter */
-        time += fm_cycles_ratio;
-      }
-      while (time < cycles);
+      time += (((cycles - time + fm_cycles_ratio - 1) / fm_cycles_ratio) + 1) * fm_cycles_ratio;
     }
 
     /* reset FM buffer pointer */
@@ -446,4 +528,44 @@ int sound_context_load(uint8 *state)
   fm_cycles_count = fm_cycles_start;
 
   return bufferptr;
+}
+
+/* Include the CD audio header files to get the cdd.audio variable */
+#include "scd.h"
+#include "cdd.h"
+
+void save_sound_buffer()
+{
+  int i;
+  snd.fm_last_save[0] = fm_last[0];
+  snd.fm_last_save[1] = fm_last[1];
+  snd.cd_last_save[0] = cdd.audio[0];
+  snd.cd_last_save[1] = cdd.audio[1];
+  for (i = 0; i < 3; i++)
+  {
+    if (snd.blips[i] != NULL)
+    {
+      if (snd.blip_states[i] == NULL)
+      {
+        snd.blip_states[i] = blip_new_buffer_state();
+      }
+      blip_save_buffer_state(snd.blips[i], snd.blip_states[i]);
+    }
+  }
+}
+
+void restore_sound_buffer()
+{
+  int i;
+  fm_last[0] = snd.fm_last_save[0];
+  fm_last[1] = snd.fm_last_save[1];
+  cdd.audio[0] = snd.cd_last_save[0];
+  cdd.audio[1] = snd.cd_last_save[1];
+  for (i = 0; i < 3; i++)
+  {
+    if (snd.blips[i] != NULL && snd.blip_states[i] != NULL)
+    {
+      blip_load_buffer_state(snd.blips[i], snd.blip_states[i]);
+    }
+  }
 }

--- a/core/sound/sound.h
+++ b/core/sound/sound.h
@@ -49,5 +49,7 @@ extern int sound_update(unsigned int cycles);
 extern void (*fm_reset)(unsigned int cycles);
 extern void (*fm_write)(unsigned int cycles, unsigned int address, unsigned int data);
 extern unsigned int (*fm_read)(unsigned int cycles, unsigned int address);
+extern void save_sound_buffer();
+extern void restore_sound_buffer();
 
 #endif /* _SOUND_H_ */

--- a/core/state.h
+++ b/core/state.h
@@ -40,7 +40,7 @@
 #define _STATE_H_
 
 #define STATE_SIZE    0xfd000
-#define STATE_VERSION "GENPLUS-GX 1.7.5"
+#define STATE_VERSION "GENPLUS-GX 1.7.6"
 
 #define load_param(param, size) \
   memcpy(param, &state[bufferptr], size); \

--- a/core/system.c
+++ b/core/system.c
@@ -42,6 +42,8 @@
 #include "shared.h"
 #include "eq.h"
 
+extern int8 audio_hard_disable;
+
 /* Global variables */
 t_bitmap bitmap;
 t_snd snd;
@@ -187,6 +189,8 @@ void audio_shutdown(void)
   {
     blip_delete(snd.blips[i]);
     snd.blips[i] = 0;
+    blip_delete_buffer_state(snd.blip_states[i]);
+    snd.blip_states[i] = 0;
   }
 }
 
@@ -209,6 +213,8 @@ int audio_update(int16 *buffer)
     size &= ALIGN_SND;
 #endif
 
+    if (audio_hard_disable) return 0;
+
     /* resample & mix FM/PSG, PCM & CD-DA streams to output buffer */
     blip_mix_samples(snd.blips[0], snd.blips[1], snd.blips[2], buffer, size);
   }
@@ -218,6 +224,8 @@ int audio_update(int16 *buffer)
     /* return an aligned number of samples if required */
     size &= ALIGN_SND;
 #endif
+
+    if (audio_hard_disable) return 0;
 
     /* resample FM/PSG mixed stream to output buffer */
     blip_read_samples(snd.blips[0], buffer, size);

--- a/core/system.c
+++ b/core/system.c
@@ -213,7 +213,13 @@ int audio_update(int16 *buffer)
     size &= ALIGN_SND;
 #endif
 
-    if (audio_hard_disable) return 0;
+    if (audio_hard_disable)
+    {
+      blip_discard_samples_dirty(snd.blips[0], size);
+      blip_discard_samples_dirty(snd.blips[1], size);
+      blip_discard_samples_dirty(snd.blips[2], size);
+      return 0;
+    }
 
     /* resample & mix FM/PSG, PCM & CD-DA streams to output buffer */
     blip_mix_samples(snd.blips[0], snd.blips[1], snd.blips[2], buffer, size);
@@ -225,7 +231,11 @@ int audio_update(int16 *buffer)
     size &= ALIGN_SND;
 #endif
 
-    if (audio_hard_disable) return 0;
+    if (audio_hard_disable)
+    {
+      blip_discard_samples_dirty(snd.blips[0], size);
+      return 0;
+    }
 
     /* resample FM/PSG mixed stream to output buffer */
     blip_read_samples(snd.blips[0], buffer, size);

--- a/core/system.h
+++ b/core/system.h
@@ -92,6 +92,9 @@ typedef struct
   double frame_rate;    /* Output Frame rate (usually 50 or 60 frames per second) */
   int enabled;          /* 1= sound emulation is enabled */
   blip_t* blips[3];     /* Blip Buffer resampling (stereo) */
+  blip_buffer_state_t *blip_states[3]; /* states for suspending and restoring the sound buffer */
+  int fm_last_save[2];  /* For saving and restoring the sound buffer */
+  int16 cd_last_save[2];  /* For saving and restoring the sound buffer */
 } t_snd;
 
 

--- a/libretro/msvc/msvc-2017.sln
+++ b/libretro/msvc/msvc-2017.sln
@@ -3,16 +3,22 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "msvc-2010", "msvc-2017\msvc-2017.vcxproj", "{29DF2EE7-2930-4BD3-8AC5-81A2534ACC99}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "msvc-2017", "msvc-2017\msvc-2017.vcxproj", "{29DF2EE7-2930-4BD3-8AC5-81A2534ACC99}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{29DF2EE7-2930-4BD3-8AC5-81A2534ACC99}.Debug|x64.ActiveCfg = Debug|x64
+		{29DF2EE7-2930-4BD3-8AC5-81A2534ACC99}.Debug|x64.Build.0 = Debug|x64
 		{29DF2EE7-2930-4BD3-8AC5-81A2534ACC99}.Debug|x86.ActiveCfg = Debug|Win32
 		{29DF2EE7-2930-4BD3-8AC5-81A2534ACC99}.Debug|x86.Build.0 = Debug|Win32
+		{29DF2EE7-2930-4BD3-8AC5-81A2534ACC99}.Release|x64.ActiveCfg = Release|x64
+		{29DF2EE7-2930-4BD3-8AC5-81A2534ACC99}.Release|x64.Build.0 = Release|x64
 		{29DF2EE7-2930-4BD3-8AC5-81A2534ACC99}.Release|x86.ActiveCfg = Release|Win32
 		{29DF2EE7-2930-4BD3-8AC5-81A2534ACC99}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection

--- a/libretro/msvc/msvc-2017/msvc-2017.vcxproj
+++ b/libretro/msvc/msvc-2017/msvc-2017.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
@@ -25,6 +33,34 @@
     <ClCompile Include="..\..\..\core\cd_hw\cdd.c" />
     <ClCompile Include="..\..\..\core\cd_hw\cd_cart.c" />
     <ClCompile Include="..\..\..\core\cd_hw\gfx.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\bitmath.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\bitreader.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\cpu.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\crc.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\fixed.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\float.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\format.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\lpc.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\lpc_intrin_avx2.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\lpc_intrin_sse.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\lpc_intrin_sse2.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\lpc_intrin_sse41.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\md5.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\memory.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\stream_decoder.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\lzma\LzFind.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\lzma\LzmaDec.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\lzma\LzmaEnc.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\zlib\adler32.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\zlib\inffast.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\zlib\inflate.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\zlib\inftrees.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\zlib\zutil.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\src\bitstream.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\src\cdrom.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\src\chd.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\src\flac.c" />
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\src\huffman.c" />
     <ClCompile Include="..\..\..\core\cd_hw\pcm.c" />
     <ClCompile Include="..\..\..\core\cd_hw\scd.c" />
     <ClCompile Include="..\..\..\core\genesis.c" />
@@ -75,6 +111,12 @@
     <ClCompile Include="..\..\..\core\vdp_ctrl.c" />
     <ClCompile Include="..\..\..\core\vdp_render.c" />
     <ClCompile Include="..\..\..\core\z80\z80.c" />
+    <ClCompile Include="..\..\libretro-common\compat\compat_strl.c" />
+    <ClCompile Include="..\..\libretro-common\compat\fopen_utf8.c" />
+    <ClCompile Include="..\..\libretro-common\encodings\encoding_utf.c" />
+    <ClCompile Include="..\..\libretro-common\streams\file_stream.c" />
+    <ClCompile Include="..\..\libretro-common\streams\file_stream_transforms.c" />
+    <ClCompile Include="..\..\libretro-common\vfs\vfs_implementation.c" />
     <ClCompile Include="..\..\libretro.c" />
     <ClCompile Include="..\..\scrc32.c" />
   </ItemGroup>
@@ -83,10 +125,16 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>msvc2017</RootNamespace>
     <ProjectName>msvc-2017</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
@@ -99,30 +147,57 @@
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)msvc-2017\$(Configuration)\</OutDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)msvc-2017\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;MSVC2017_EXPORTS;_CRT_SECURE_NO_WARNINGS;INLINE=static _inline;__inline__=_inline;__extension__=;LSB_FIRST;__LIBRETRO__;USE_16BPP_RENDERING;FRONTEND_SUPPORTS_RGB565;%(PreprocessorDefinitions);USE_LIBTREMOR;BYTE_ORDER=LITTLE_ENDIAN</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../../core;$(SolutionDir)/../../utils/zlib;$(SolutionDir)/../../core/cart_hw/svp;$(SolutionDir)/../../libretro;$(SolutionDir)/../../core/m68k;$(SolutionDir)/../../core/z80;$(SolutionDir)/../../core/input_hw;$(SolutionDir)/../../core/cart_hw;$(SolutionDir)/../../core/sound;$(SolutionDir)/../../core/ntsc;$(SolutionDir)/../../core/cd_hw;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../../core;$(SolutionDir)/../../utils/zlib;$(SolutionDir)/../../core/cart_hw/svp;$(SolutionDir)/../../libretro;$(SolutionDir)/../../core/m68k;$(SolutionDir)/../../core/z80;$(SolutionDir)/../../core/input_hw;$(SolutionDir)/../../core/cart_hw;$(SolutionDir)/../../core/sound;$(SolutionDir)/../../core/ntsc;$(SolutionDir)/../../core/cd_hw;$(SolutionDir)/../libretro-common/include/;$(SolutionDir)/../../core/cd_hw/libchdr/deps/libFLAC/include;$(SolutionDir)/../../core/cd_hw/libchdr/deps/lzma;$(SolutionDir)/../../core/cd_hw/libchdr/deps/zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;MSVC2017_EXPORTS;_CRT_SECURE_NO_WARNINGS;INLINE=static __inline;__inline__=__inline;__extension__=;LSB_FIRST;__LIBRETRO__;USE_16BPP_RENDERING;FRONTEND_SUPPORTS_RGB565;USE_LIBTREMOR;BYTE_ORDER=LITTLE_ENDIAN;HAVE_YM3438_CORE;USE_LIBCHDR;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;_7ZIP_ST;HAVE_STDINT_H;HAVE_STDLIB_H;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>libretro.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../../core;$(SolutionDir)/../../utils/zlib;$(SolutionDir)/../../core/cart_hw/svp;$(SolutionDir)/../../libretro;$(SolutionDir)/../../core/m68k;$(SolutionDir)/../../core/z80;$(SolutionDir)/../../core/input_hw;$(SolutionDir)/../../core/cart_hw;$(SolutionDir)/../../core/sound;$(SolutionDir)/../../core/ntsc;$(SolutionDir)/../../core/cd_hw;$(SolutionDir)/../libretro-common/include/;$(SolutionDir)/../../core/cd_hw/libchdr/deps/libFLAC/include;$(SolutionDir)/../../core/cd_hw/libchdr/deps/lzma;$(SolutionDir)/../../core/cd_hw/libchdr/deps/zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;MSVC2017_EXPORTS;_CRT_SECURE_NO_WARNINGS;INLINE=static __inline;__inline__=__inline;__extension__=;LSB_FIRST;__LIBRETRO__;USE_16BPP_RENDERING;FRONTEND_SUPPORTS_RGB565;USE_LIBTREMOR;BYTE_ORDER=LITTLE_ENDIAN;HAVE_YM3438_CORE;USE_LIBCHDR;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;_7ZIP_ST;HAVE_STDINT_H;HAVE_STDLIB_H;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -133,13 +208,36 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;MSVC2017_EXPORTS;_CRT_SECURE_NO_WARNINGS;INLINE=static _inline;__inline__=_inline;__extension__=;LSB_FIRST;__LIBRETRO__;USE_16BPP_RENDERING;FRONTEND_SUPPORTS_RGB565;%(PreprocessorDefinitions);USE_LIBTREMOR;BYTE_ORDER=LITTLE_ENDIAN</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../../core;$(SolutionDir)/../../utils/zlib;$(SolutionDir)/../../core/cart_hw/svp;$(SolutionDir)/../../libretro;$(SolutionDir)/../../core/m68k;$(SolutionDir)/../../core/z80;$(SolutionDir)/../../core/input_hw;$(SolutionDir)/../../core/cart_hw;$(SolutionDir)/../../core/sound;$(SolutionDir)/../../core/ntsc;$(SolutionDir)/../../core/cd_hw;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../../core;$(SolutionDir)/../../utils/zlib;$(SolutionDir)/../../core/cart_hw/svp;$(SolutionDir)/../../libretro;$(SolutionDir)/../../core/m68k;$(SolutionDir)/../../core/z80;$(SolutionDir)/../../core/input_hw;$(SolutionDir)/../../core/cart_hw;$(SolutionDir)/../../core/sound;$(SolutionDir)/../../core/ntsc;$(SolutionDir)/../../core/cd_hw;$(SolutionDir)/../libretro-common/include/;$(SolutionDir)/../../core/cd_hw/libchdr/deps/libFLAC/include;$(SolutionDir)/../../core/cd_hw/libchdr/deps/lzma;$(SolutionDir)/../../core/cd_hw/libchdr/deps/zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;MSVC2017_EXPORTS;_CRT_SECURE_NO_WARNINGS;INLINE=static __inline;__inline__=__inline;__extension__=;LSB_FIRST;__LIBRETRO__;USE_16BPP_RENDERING;FRONTEND_SUPPORTS_RGB565;USE_LIBTREMOR;BYTE_ORDER=LITTLE_ENDIAN;HAVE_YM3438_CORE;USE_LIBCHDR;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;_7ZIP_ST;HAVE_STDINT_H;HAVE_STDLIB_H;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>libretro.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../../core;$(SolutionDir)/../../utils/zlib;$(SolutionDir)/../../core/cart_hw/svp;$(SolutionDir)/../../libretro;$(SolutionDir)/../../core/m68k;$(SolutionDir)/../../core/z80;$(SolutionDir)/../../core/input_hw;$(SolutionDir)/../../core/cart_hw;$(SolutionDir)/../../core/sound;$(SolutionDir)/../../core/ntsc;$(SolutionDir)/../../core/cd_hw;$(SolutionDir)/../libretro-common/include/;$(SolutionDir)/../../core/cd_hw/libchdr/deps/libFLAC/include;$(SolutionDir)/../../core/cd_hw/libchdr/deps/lzma;$(SolutionDir)/../../core/cd_hw/libchdr/deps/zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;MSVC2017_EXPORTS;_CRT_SECURE_NO_WARNINGS;INLINE=static __inline;__inline__=__inline;__extension__=;LSB_FIRST;__LIBRETRO__;USE_16BPP_RENDERING;FRONTEND_SUPPORTS_RGB565;USE_LIBTREMOR;BYTE_ORDER=LITTLE_ENDIAN;HAVE_YM3438_CORE;USE_LIBCHDR;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;_7ZIP_ST;HAVE_STDINT_H;HAVE_STDLIB_H;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/libretro/msvc/msvc-2017/msvc-2017.vcxproj.filters
+++ b/libretro/msvc/msvc-2017/msvc-2017.vcxproj.filters
@@ -43,6 +43,24 @@
     <Filter Include="Source Files\tremor">
       <UniqueIdentifier>{c4a5e1da-1ff3-4c81-893c-97364ed7ed4b}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\libretro-common">
+      <UniqueIdentifier>{0bcbca3b-7435-43fd-b326-345e29319174}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cd_hw\libchdr">
+      <UniqueIdentifier>{fab41b84-b923-4fb1-87bf-62fe66c164e0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cd_hw\libchdr\deps">
+      <UniqueIdentifier>{38ead1c3-a481-4459-9504-d15bb7df1e20}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cd_hw\libchdr\deps\flac">
+      <UniqueIdentifier>{d263bf90-91f4-4095-a4d7-2819f7c487ba}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cd_hw\libchdr\deps\lzma">
+      <UniqueIdentifier>{2d66f06d-9582-4724-b680-317a6ec634d9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cd_hw\libchdr\deps\zlib">
+      <UniqueIdentifier>{8943a4d0-69c9-40bf-a571-be5bf9d93528}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\core\cart_hw\svp\svp.c">
@@ -66,13 +84,13 @@
     <ClCompile Include="..\..\..\core\cart_hw\sms_cart.c">
       <Filter>Source Files\cart_hw</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\core\input_hw\xe_a1p.c">
-      <Filter>Source Files\input_hw</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\core\input_hw\activator.c">
       <Filter>Source Files\input_hw</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\core\input_hw\gamepad.c">
+      <Filter>Source Files\input_hw</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\input_hw\graphic_board.c">
       <Filter>Source Files\input_hw</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\core\input_hw\input.c">
@@ -94,6 +112,9 @@
       <Filter>Source Files\input_hw</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\core\input_hw\terebi_oekaki.c">
+      <Filter>Source Files\input_hw</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\input_hw\xe_1ap.c">
       <Filter>Source Files\input_hw</Filter>
     </ClCompile>
     <ClCompile Include="..\..\libretro.c">
@@ -124,6 +145,9 @@
       <Filter>Source Files\sound</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\core\sound\ym2413.c">
+      <Filter>Source Files\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\sound\ym3438.c">
       <Filter>Source Files\sound</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\core\z80\z80.c">
@@ -236,6 +260,108 @@
     </ClCompile>
     <ClCompile Include="..\..\..\core\tremor\vorbisfile.c">
       <Filter>Source Files\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libretro-common\vfs\vfs_implementation.c">
+      <Filter>Source Files\libretro-common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libretro-common\streams\file_stream.c">
+      <Filter>Source Files\libretro-common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libretro-common\streams\file_stream_transforms.c">
+      <Filter>Source Files\libretro-common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libretro-common\encodings\encoding_utf.c">
+      <Filter>Source Files\libretro-common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libretro-common\compat\fopen_utf8.c">
+      <Filter>Source Files\libretro-common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libretro-common\compat\compat_strl.c">
+      <Filter>Source Files\libretro-common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\bitmath.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\bitreader.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\cpu.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\crc.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\fixed.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\float.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\format.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\lpc.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\lpc_intrin_avx2.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\lpc_intrin_sse.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\lpc_intrin_sse2.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\lpc_intrin_sse41.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\md5.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\memory.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\libFLAC\stream_decoder.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\lzma\LzFind.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\lzma\LzmaDec.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\zlib\adler32.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\zlib\inffast.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\zlib\inflate.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\zlib\inftrees.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\zlib\zutil.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\src\bitstream.c">
+      <Filter>Source Files\cd_hw\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\src\cdrom.c">
+      <Filter>Source Files\cd_hw\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\src\chd.c">
+      <Filter>Source Files\cd_hw\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\src\flac.c">
+      <Filter>Source Files\cd_hw\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\src\huffman.c">
+      <Filter>Source Files\cd_hw\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\core\cd_hw\libchdr\deps\lzma\LzmaEnc.c">
+      <Filter>Source Files\cd_hw\libchdr\deps\lzma</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/libretro/msvc/msvc-2017/msvc-2017.vcxproj.user
+++ b/libretro/msvc/msvc-2017/msvc-2017.vcxproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ShowAllFiles>true</ShowAllFiles>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
* Saves and loads the audio buffer state for clean audio at 0 runahead
* Clean audio for Sega CD PCM when loading state
* Clean audio for CD Audio when loading state by saving the sample position.  Supported for CD images, Vorbis tracks, and CHD images.
* Loading state no longer invalidates tile cache, so emulator doesn't have to recreate it after loading state, big speedup
* Hard disable audio support cleaned up and re-added.  Now it uses some dummy callbacks to replace the FM synthesis.
* Fixed Savestates saved or loaded during TMSS bootrom
* MSVC project updated, featuring full libchdr support
* Removed the ".user" file from the MSVC project, added to git ignore list