### PR TITLE
[3DS] Enable CPU filters when loading Game Gear content

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2012,8 +2012,18 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 {
    info->geometry.base_width    = vwidth;
    info->geometry.base_height   = bitmap.viewport.h + (2 * bitmap.viewport.y);
+#ifdef _3DS
+   if (system_hw == SYSTEM_GG) {
+      info->geometry.max_width  = info->geometry.base_width;
+      info->geometry.max_height = info->geometry.base_height;
+   } else {
+      info->geometry.max_width  = 720;
+      info->geometry.max_height = 576;
+   }
+#else
    info->geometry.max_width     = 720;
    info->geometry.max_height    = 576;
+#endif
    info->geometry.aspect_ratio  = vaspect_ratio;
    info->timing.fps             = (double)(system_clock) / (double)lines_per_frame / (double)MCYCLES_PER_LINE;
    info->timing.sample_rate     = SOUND_FREQUENCY;


### PR DESCRIPTION
Currently, the core produces a black screen when attempting to use CPU filters on the 3DS (issue #156).

It turns out that this is a 3DS hardware limitation - it just doesn't have enough heap space. The 'problem' is that the core sets a very large max width/height in retro_get_system_av_info(). All the upscaling CPU filters double these values when allocating a frame buffer, so we end up with 1440x1152 - this is huge! The 3DS can't handle it, so no texture gets uploaded and we get a blank screen (at least it doesn't crash, which is nice...).

The only way around this is to reduce the max width/height. This is a little sticky, since the core emulates multiple systems and things become convoluted with in-game resolution changes and various aspect ratio shenanigans. Since Genesis and Master System games don't really benefit from CPU filters anyway (native resolution is a little too high, and 1:1 pixel mapping works nicely on the 240p 3DS screen), I though it best to avoid extensive changes to the code. Instead I focussed on the Game Gear, which is the only system that actively *needs* filtering, and which has a guaranteed 'safe' resolution (i.e. it can't ever exceed the heap space).

This pull request therefore does one very tiny thing: if (platform == 3DS) and (emulated system == Game Gear), the system_av_info max width/height are set to the actual emulated system screen dimensions. I understand that this smells like a hack, but as far as I can tell it is completely safe, and CPU filters can now be used.

So instead of this, which is disgusting:

![royal stone japan en v1 00 gg -181105-144409](https://user-images.githubusercontent.com/38211560/48008808-48181980-e112-11e8-8d6c-185572694879.png)

We can have something like this (Normal2x):

![royal stone japan en v1 00 gg -181105-144422](https://user-images.githubusercontent.com/38211560/48009086-db514f00-e112-11e8-98da-caa4407eeafa.png)

...or this (Scale2x):

![royal stone japan en v1 00 gg -181105-144435](https://user-images.githubusercontent.com/38211560/48009092-dd1b1280-e112-11e8-923b-0375edc8b252.png)

...both of which are markedly superior to the output of the official 3DS Game Gear Virtual Console emulator. (And the core is so efficient that all games run at full speed with Scale2x even on an o3DS!)

As an aside, it would probably be a good idea to modify the CTR video driver so CPU filters are automatically disabled if their use would exceed the heap space. I will try to look at this if I have time...