### PR TITLE
Update core options

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -7,11 +7,20 @@
 #include <libretro.h>
 #include <retro_inline.h>
 
+#ifndef HAVE_NO_LANGEXTRA
+#include "libretro_core_options_intl.h"
+#endif
+
 /*
  ********************************
- * VERSION: 1.2
+ * VERSION: 1.3
  ********************************
  *
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
  * - 1.2: Use core options v1 interface when
  *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
  *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
@@ -52,8 +61,8 @@ extern "C" {
 struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_system_hw",
-      "System hardware",
-      "Choose which system is going to be emulated.",
+      "System Hardware",
+      "Runs loaded content with a specific emulated console. 'Auto' will select the most appropriate system for the current game.",
       {
          { "auto",                 "Auto"               },
          { "sg-1000",              "SG-1000"            },
@@ -69,8 +78,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_region_detect",
-      "System region",
-      "Choose which region the system is from.",
+      "System Region",
+      "Specify which region the system is from. For consoles other than the Game Gear, 'PAL' is 50hz while 'NTSC' is 60hz. Games may run faster or slower than normal if the incorrect region is selected.",
       {
          { "auto",    "Auto"   },
          { "ntsc-u",  "NTSC-U" },
@@ -82,8 +91,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_force_dtack",
-      "System lockups",
-      "Emulate system lockups that occur on real hardware.",
+      "System Lock-Ups",
+      "Emulate system lock-ups that occur on real hardware when performing illegal address access. This should only be disabled when playing certain demos and homebrew that rely on illegal behaviour for correct operation.",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
@@ -93,8 +102,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_bios",
-      "System boot ROM",
-      "Runs bootrom if available and then starts loaded content after the boot sequence. Optional. Should be called 'bios_MD.bin'.",
+      "System Boot ROM",
+      "Use official BIOS/bootloader for emulated hardware, if present in RetroArch's system directory. Displays console-specific start-up sequence/animation, then runs loaded content.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -105,7 +114,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_bram",
       "CD System BRAM",
-      "The Sega CD's internal memory cannot hold a lot of saves. Setting this core option to per game allows each game to have its own one BRM file, thus negating any lack of available space issues.",
+      "When running Sega CD content, specifies whether to share a single save file between all games from a specific region (Per-BIOS) or to create a separate save file for each game (Per-Game). Note that the Sega CD has limited internal storage, sufficient only for a handful of titles. To avoid running out of space, the 'Per-Game' setting is recommended.",
       {
          { "per bios", "Per-BIOS" },
          { "per game", "Per-Game" },
@@ -115,8 +124,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_addr_error",
-      "68K address error",
-      "Emulate the 68K address error that occurs on real hardware. Set this to disabled when playing ROM hacks since most emulators used to develop ROM hacks don't emulate the error.",
+      "68K Address Error",
+      "The Genesis CPU (Motorola 68000) produces an Address Error (crash) when attempting to perform unaligned memory access. Enabling '68K Address Error' simulates this behaviour. It should only be disabled when playing ROM hacks, since these are typically developed using less accurate emulators and may rely on invalid RAM access for correct operation.",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
@@ -126,8 +135,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_lock_on",
-      "Cartridge lock-on",
-      "Select a lock-on cartridge.",
+      "Cartridge Lock-On",
+      "Lock-On Technology is a Genesis feature that allowed an older game to connect to the pass-through port of a special cartridge for extended or altered gameplay. This option specifies which type of special 'lock-on' cartridge to emulate. A corresponding bios file must be present in RetroArch's system directory.",
       {
          { "disabled",            NULL },
          { "game genie",          "Game Genie" },
@@ -140,7 +149,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_ym2413",
       "Master System FM (YM2413)",
-      "Enable the Master System FM chip. (Enhanced sound output support for SMS compatible games)",
+      "Enable emulation of the FM Sound Unit used by certain Sega Mark III/Master System games for enhanced audio output.",
       {
          { "auto",     "Auto" },
          { "disabled", NULL },
@@ -152,7 +161,11 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_ym2612",
       "Mega Drive / Genesis FM",
-      "Awaiting description.",
+#ifdef HAVE_YM3438_CORE
+      "Select method used to emulate the FM synthesizer (main sound generator) of the Mega Drive/Genesis. 'MAME' options are fast, and run full speed on most systems. 'Nuked' options are cycle accurate, very high quality, and have substantial CPU requirements. The 'YM2612' chip is used by the original Model 1 Genesis. The 'YM3438' is used in later Genesis revisions.",
+#else
+      "Select method used to emulate the FM synthesizer (main sound generator) of the Mega Drive/Genesis. The 'YM2612' chip is used by the original Model 1 Genesis. The 'YM3438' is used in later Genesis revisions.",
+#endif
       {
          { "mame (ym2612)",          "MAME (YM2612)" },
          { "mame (asic ym3438)",     "MAME (ASIC YM3438)" },
@@ -167,8 +180,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_sound_output",
-      "Sound output",
-      "Self-explanatory.",
+      "Sound Output",
+      "Select stereo or mono sound reproduction.",
       {
          { "stereo", "Stereo" },
          { "mono",   "Mono" },
@@ -178,8 +191,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_psg_preamp",
-      "PSG preamp level",
-      "Awaiting description.",
+      "PSG Preamp Level",
+      "Set the audio preamplifier level of the emulated SN76496 4-channel Programmable Sound Generator found in the Master System, Game Gear and Genesis.",
       {
          { "0",   NULL },
          { "5",   NULL },
@@ -228,8 +241,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_fm_preamp",
-      "FM preamp level",
-      "Awaiting description.",
+      "FM Preamp Level",
+      "Set the audio preamplifier level of the emulated Sega Mark III/Master System FM Sound Unit.",
       {
          { "0",   NULL },
          { "5",   NULL },
@@ -278,8 +291,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_audio_filter",
-      "Audio filter",
-      "Awaiting description.",
+      "Audio Filter",
+      "Enable a low pass audio filter to better simulate the characteristic sound of a Model 1 Genesis.",
       {
          { "disabled", NULL },
          { "low-pass", "Low-Pass" },
@@ -289,8 +302,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_lowpass_range",
-      "Low-pass filter %",
-      "Awaiting description.",
+      "Low-Pass Filter %",
+      "Specify the cut-off frequency of the audio low pass filter. A higher value increases the perceived 'strength' of the filter, since a wider range of the high frequency spectrum is attenuated.",
       {
          { "5",  NULL },
          { "10", NULL },
@@ -319,7 +332,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_audio_eq_low",
       "EQ Low",
-      "Awaiting description.",
+      "Adjust the low range band of the internal audio equaliser.",
       {
          { "0",   NULL },
          { "5",   NULL },
@@ -349,7 +362,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_audio_eq_mid",
       "EQ Mid",
-      "Awaiting description.",
+      "Adjust the middle range band of the internal audio equaliser.",
       {
          { "0",   NULL },
          { "5",   NULL },
@@ -379,7 +392,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_audio_eq_high",
       "EQ High",
-      "Awaiting description.",
+      "Adjust the high range band of the internal audio equaliser.",
       {
          { "0",   NULL },
          { "5",   NULL },
@@ -409,8 +422,8 @@ struct retro_core_option_definition option_defs_us[] = {
 #endif
    {
       "genesis_plus_gx_blargg_ntsc_filter",
-      "Blargg NTSC filter",
-      "Self-explanatory.",
+      "Blargg NTSC Filter",
+      "Apply a video filter to mimic various NTSC TV signals.",
       {
          { "disabled",   NULL },
          { "monochrome", "Monochrome" },
@@ -423,8 +436,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_lcd_filter",
-      "LCD Ghosting filter",
-      "Self-explanatory.",
+      "LCD Ghosting Filter",
+      "Apply an image 'ghosting' filter to mimic the display characteristics of the Game Gear and 'Genesis Nomad' LCD panels.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -435,7 +448,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_overscan",
       "Borders",
-      "Self-explanatory.",
+      "Enable this to display the overscan regions at the top/bottom and/or left/right of the screen. These would normally be hidden by the bezel around the edge of a standard-definition television.",
       {
          { "disabled",   NULL },
          { "top/bottom", "Top/Bottom" },
@@ -447,8 +460,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_gg_extra",
-      "Game Gear extended screen",
-      "Self-explanatory.",
+      "Game Gear Extended Screen",
+      "Forces Game Gear titles to run in 'SMS' mode, with an increased resolution of 256x192. May show additional content, but typically displays a border of corrupt/unwanted image data.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -458,8 +471,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_aspect_ratio",
-      "Core-provided aspect ratio",
-      "Choose the Core-provided aspect ratio. RetroArch's aspect ratio must be set to Core provided in the Video settings for this to function properly.",
+      "Core-Provided Aspect Ratio",
+      "Choose the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",
       {
          { "auto",     "Auto" },
          { "NTSC PAR", NULL },
@@ -469,8 +482,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_render",
-      "Interlaced mode 2 output",
-      "Change how interlaced mode 2 output is handled. Games like Sonic 2's multiplayer mode uses Interlaced Mode 2.",
+      "Interlaced Mode 2 Output",
+      "Interlaced Mode 2 allows the Genesis to output a double height (high resolution) 320x448 image by drawing alternate scanlines each frame (this is used by 'Sonic the Hedgehog 2' and 'Combat Cars' multiplayer modes). 'Double Field' mimics original hardware, producing a sharp image with flickering/interlacing artefacts. 'Single Field' apples a de-interlacing filter, which stabilises the image but causes mild blurring.",
       {
          { "single field", "Single Field" },
          { "double field", "Double Field" },
@@ -480,8 +493,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_gun_cursor",
-      "Show Lightgun crosshair",
-      "Shows lightgun crosshairs for the 'MD Menacer', 'MD Justifiers', and 'MS Light Phaser' Device Types.",
+      "Show Light Gun Crosshair",
+      "Display light gun crosshairs when using the 'MD Menacer', 'MD Justifiers' and 'MS Light Phaser' input device types.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -491,10 +504,10 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_gun_input",
-      "Lightgun input",
-      "Self-explanatory.",
+      "Light Gun Input",
+      "Use a mouse-controlled 'Light Gun' or 'Touchscreen' input.",
       {
-         { "lightgun",    "Lightgun" },
+         { "lightgun",    "Light Gun" },
          { "touchscreen", "Touchscreen" },
          { NULL, NULL },
       },
@@ -503,7 +516,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_invert_mouse",
       "Invert Mouse Y-Axis",
-      "Inverts the Mouse Y-axis for the 'MD Mouse' Device Type.",
+      "Inverts the Y-axis of the 'MD Mouse' input device type.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -514,8 +527,8 @@ struct retro_core_option_definition option_defs_us[] = {
 #ifdef HAVE_OVERCLOCK
    {
       "genesis_plus_gx_overclock",
-      "CPU speed",
-      "Overclock the emulated CPU.",
+      "CPU Speed",
+      "Overclock the emulated CPU. Can reduce slowdown, but may cause glitches.",
       {
          { "100%", NULL },
          { "125%", NULL },
@@ -529,8 +542,8 @@ struct retro_core_option_definition option_defs_us[] = {
 #endif
    {
       "genesis_plus_gx_no_sprite_limit",
-      "Remove per-line sprite limit",
-      "Reduce sprite flickering when enabled..",
+      "Remove Per-Line Sprite Limit",
+      "Removes the 8 (Master System) or 20 (Genesis) sprite-per-scanline hardware limit. This reduces flickering but can cause visual glitches, as some games exploit the hardware limit to generate special effects.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -541,48 +554,13 @@ struct retro_core_option_definition option_defs_us[] = {
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 
-/* RETRO_LANGUAGE_JAPANESE */
-
-/* RETRO_LANGUAGE_FRENCH */
-
-/* RETRO_LANGUAGE_SPANISH */
-
-/* RETRO_LANGUAGE_GERMAN */
-
-/* RETRO_LANGUAGE_ITALIAN */
-
-/* RETRO_LANGUAGE_DUTCH */
-
-/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
-
-/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
-
-/* RETRO_LANGUAGE_RUSSIAN */
-
-/* RETRO_LANGUAGE_KOREAN */
-
-/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
-
-/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
-
-/* RETRO_LANGUAGE_ESPERANTO */
-
-/* RETRO_LANGUAGE_POLISH */
-
-/* RETRO_LANGUAGE_VIETNAMESE */
-
-/* RETRO_LANGUAGE_ARABIC */
-
-/* RETRO_LANGUAGE_GREEK */
-
-/* RETRO_LANGUAGE_TURKISH */
-
 /*
  ********************************
  * Language Mapping
  ********************************
 */
 
+#ifndef HAVE_NO_LANGEXTRA
 struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
    option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
    NULL,           /* RETRO_LANGUAGE_JAPANESE */
@@ -604,6 +582,7 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
    NULL,           /* RETRO_LANGUAGE_GREEK */
    NULL,           /* RETRO_LANGUAGE_TURKISH */
 };
+#endif
 
 /*
  ********************************
@@ -628,6 +607,7 @@ INLINE void libretro_set_core_options(retro_environment_t environ_cb)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
    {
+#ifndef HAVE_NO_LANGEXTRA
       struct retro_core_options_intl core_options_intl;
       unsigned language = 0;
 
@@ -639,6 +619,9 @@ INLINE void libretro_set_core_options(retro_environment_t environ_cb)
          core_options_intl.local = option_defs_intl[language];
 
       environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+#else
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, &option_defs_us);
+#endif
    }
    else
    {

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -1,0 +1,80 @@
+﻿#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+#define LIBRETRO_CORE_OPTIONS_INTL_H__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
+
+#include <libretro.h>
+
+/*
+ ********************************
+ * VERSION: 1.3
+ ********************************
+ *
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_JAPANESE */
+
+/* RETRO_LANGUAGE_FRENCH */
+
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR:

- Updates `libretro_core_options` to v1.3 format

- Converts all core option descriptions to title case

- Adds all missing core option sublabels

- Improves all existing core option sublabels