### PR TITLE
don't reset overclock delay in unserialize

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2481,7 +2481,6 @@ bool retro_unserialize(const void *data, size_t size)
    if (fast_savestates) restore_sound_buffer();
 
 #ifdef HAVE_OVERCLOCK
-   overclock_delay = OVERCLOCK_FRAME_DELAY;
    update_overclock();
 #endif
 


### PR DESCRIPTION
fix https://github.com/libretro/Genesis-Plus-GX/issues/195

Run Ahead is working fine with both Run Ahead modes and I can't spot any problem saving/loading while the cpu is set to 200%.