### PR TITLE
Allow full access to Sega-CD's prg ram using retro_memory_map

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2078,6 +2078,35 @@ void ROMCheatUpdate(void)
   }
 }
 
+static void set_memory_maps()
+{
+   const size_t SCD_BIT = 1ULL << 31ULL;
+   struct retro_memory_descriptor descs[8];
+   struct retro_memory_map        mmaps;
+   int i = 0;
+
+   memset(descs, 0, sizeof(descs));
+
+   if (system_hw == SYSTEM_MCD)
+   {
+      /* virtual address using SCD_BIT so all 512M of prg_ram can be access
+       * effectively address $ 80020000 */
+      descs[i].ptr       = (unsigned char*)scd.prg_ram;
+      descs[i].len       = 0x80000;
+      descs[i].start     = SCD_BIT | 0x020000;
+      descs[i].flags     = RETRO_MEMDESC_SYSTEM_RAM;
+      descs[i].addrspace = "PRGRAM";
+      i++;
+   }
+
+   if (!i)
+      return;
+
+   mmaps.descriptors = descs;
+   mmaps.num_descriptors = i;
+   environ_cb(RETRO_ENVIRONMENT_SET_MEMORY_MAPS, &mmaps);
+}
+
 /************************************
  * libretro implementation
  ************************************/
@@ -2662,6 +2691,8 @@ bool retro_load_game(const struct retro_game_info *info)
    overclock_delay = OVERCLOCK_FRAME_DELAY;
    update_overclock();
 #endif
+
+   set_memory_maps();
 
    return true;
 }


### PR DESCRIPTION
This PR allows access to the full size of Sega CD's prg ram to libretro api using retro_memory_map

Since prg_ram is accessible by banks, a virtual address is used and assigned at $80020000 to access the full 524288 bytes block of prg ram. 

This memory map only takes affects when a Sega CD is detected. non-Sega CD games/system will take the normal retro_get_memory_data/size to access system ram (and sram if needed).

The same ram regions can also be used for retroarch's own cheat engine, which effectively shows as address address 0 - $7FFFF

Reference : https://github.com/libretro/Genesis-Plus-GX/issues/191