### PR TITLE
Touchscreen Lightgun: Use multi-touch to simulate pressing alternate buttons

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -378,6 +378,14 @@ static void osd_input_update_internal_bitmasks(void)
                   input.analog[i][1] = ((input_state_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y) + 0x7fff) * bitmap.viewport.h) / 0xfffe;
                   if (input_state_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED))
                      temp |= INPUT_A;
+                  int touch_count = input_state_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_COUNT);
+                  if (touch_count == 2) {
+                     temp |= INPUT_B;
+                  } else if (touch_count == 3) {
+                     temp |= INPUT_START;
+                  } else if (touch_count == 4) {
+                     temp |= INPUT_C;
+                  }
                }
                else
                {  // RetroLightgun is default


### PR DESCRIPTION
I was playing Snatcher on Sega CD and set up play for using the Justifier by setting Port 2 to be MD Justifiers on my iPhone.

Snatcher requires you to press the Justifier START button to enable shooting. I had added support for the `RETRO_DEVICE_ID_POINTER_COUNT` input value awhile back to RetroArch so added support for this in this core. Now I can play Snatcher using the touch light gun 🙂 

For the light gun:
2-finger tap => Second trigger button
3-finger tap => START button
4-finger tap => Third trigger button (not sure if this is even being used by any game)