### PR TITLE
added .bms extension to supported extensions

### DIFF
--- a/core/loadrom.c
+++ b/core/loadrom.c
@@ -603,6 +603,11 @@ int load_rom(char *filename)
       /* Master System II hardware */
       system_hw = SYSTEM_SMS2;
     }
+    else if (!memcmp("BMS", &extension[0], 3))
+    {
+      /* Master System II hardware but it's Brazil because TecToy is weird */
+      system_hw = SYSTEM_SMS2;
+    }
     else if (!memcmp("GG", &extension[1], 2))
     {
       /* Game Gear hardware (GG mode) */

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2547,7 +2547,7 @@ void retro_get_system_info(struct retro_system_info *info)
 #define GIT_VERSION ""
 #endif
    info->library_version = "v1.7.4" GIT_VERSION;
-   info->valid_extensions = "mdx|md|smd|gen|bin|cue|iso|chd|sms|gg|sg";
+   info->valid_extensions = "mdx|md|smd|gen|bin|cue|iso|chd|bms|sms|gg|sg";
    info->block_extract = false;
    info->need_fullpath = true;
 }


### PR DESCRIPTION
.bms is a file extension used by TecToy for the 16 SEGA Master System ROMs exclusive to the Megadrive 4. It uses the same ROM format as a standard SMS ROM but it uses a .bms extension for some reason. We added it to the supported extensions lists so people can load those ROMs more easily and because it's official. ~Tammy