### PR TITLE
Add an option to remove left side border ( Sega Master System)

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2375,6 +2375,7 @@ void retro_set_environment(retro_environment_t cb)
       { "genesis_plus_gx_lcd_filter", "LCD Ghosting filter; disabled|enabled" },
       { "genesis_plus_gx_overscan", "Borders; disabled|top/bottom|left/right|full" },
       { "genesis_plus_gx_gg_extra", "Game Gear extended screen; disabled|enabled" },
+      { "genesis_plus_gx_left_border", "Hide Master System Left Border; disabled|enabled" },
       { "genesis_plus_gx_aspect_ratio", "Core-provided aspect ratio; auto|NTSC PAR|PAL PAR" },
       { "genesis_plus_gx_render", "Interlaced mode 2 output; single field|double field" },
       { "genesis_plus_gx_gun_cursor", "Show Lightgun crosshair; disabled|enabled" },

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1191,6 +1191,11 @@ static bool update_viewport(void)
       else
          vwidth = SMS_NTSC_OUT_WIDTH(vwidth);
    }
+   
+   if ((system_hw == SYSTEM_SMS || system_hw == SYSTEM_SMS2) && config.left_border)
+   {
+	   bitmap.viewport.x = (config.overscan & 2) ? 7 : -8;
+   }
 
    if (config.render && interlaced)
    {
@@ -1901,7 +1906,6 @@ static void check_variables(bool first_run)
   if (update_viewports)
   {
     bitmap.viewport.changed = 11;
-  }
     if ((system_hw == SYSTEM_GG) && !config.gg_extra)
 	{
       bitmap.viewport.x = (config.overscan & 2) ? 14 : -48;
@@ -1913,6 +1917,7 @@ static void check_variables(bool first_run)
     else
     {
       bitmap.viewport.x = (config.overscan & 2) * 7 ;
+	}
   }
 
   /* Reinitialise frameskipping, if required */

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -938,6 +938,7 @@ static void config_default(void)
    config.ntsc     = 0;
    config.lcd      = 0;
    config.render   = 0;
+   config.left_border = 0;
 
    /* input options */
    input.system[0] = SYSTEM_GAMEPAD;
@@ -1763,6 +1764,18 @@ static void check_variables(bool first_run)
       config.invert_mouse = 1;
   }
 
+  var.key = "genesis_plus_gx_left_border";
+  environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var);
+  {
+    orig_value = config.left_border;
+    if (!var.value || !strcmp(var.value, "disabled"))
+      config.left_border = 0;
+    else if (var.value && !strcmp(var.value, "enabled"))
+      config.left_border = 1;
+    if (orig_value != config.left_border)
+      update_viewports = true;
+  }
+
 #ifdef HAVE_OVERCLOCK
   var.key = "genesis_plus_gx_overclock";
   environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var);
@@ -1888,12 +1901,22 @@ static void check_variables(bool first_run)
   if (update_viewports)
   {
     bitmap.viewport.changed = 11;
-    if ((system_hw == SYSTEM_GG) && !config.gg_extra)
+    if ((system_hw == SYSTEM_GGMS) && !config.gg_extra)
       bitmap.viewport.x = (config.overscan & 2) ? 14 : -48;
+    if ((system_hw == SYSTEM_SMS || system_hw == SYSTEM_SMS2) && config.left_border)
+      bitmap.viewport.x = (config.overscan & 2) ? 7 : -8;
+    else
+      bitmap.viewport.x = (config.overscan & 2) * 7 ;
+  }
+  
+    if (update_viewports)
+  {
+    bitmap.viewport.changed = 10;
+
     else
       bitmap.viewport.x = (config.overscan & 2) * 7;
   }
-
+   
   /* Reinitialise frameskipping, if required */
   if ((update_frameskip || reinit) && !first_run)
     init_frameskip();

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1901,22 +1901,20 @@ static void check_variables(bool first_run)
   if (update_viewports)
   {
     bitmap.viewport.changed = 11;
-    if ((system_hw == SYSTEM_GGMS) && !config.gg_extra)
+  }
+    if ((system_hw == SYSTEM_GG) && !config.gg_extra)
+	{
       bitmap.viewport.x = (config.overscan & 2) ? 14 : -48;
-    if ((system_hw == SYSTEM_SMS || system_hw == SYSTEM_SMS2) && config.left_border)
-      bitmap.viewport.x = (config.overscan & 2) ? 7 : -8;
+	}
+    else if ((system_hw == SYSTEM_SMS || system_hw == SYSTEM_SMS2) && config.left_border)
+    {
+	   bitmap.viewport.x = (config.overscan & 2) ? 7 : -8;
+	}
     else
+    {
       bitmap.viewport.x = (config.overscan & 2) * 7 ;
   }
-  
-    if (update_viewports)
-  {
-    bitmap.viewport.changed = 10;
 
-    else
-      bitmap.viewport.x = (config.overscan & 2) * 7;
-  }
-   
   /* Reinitialise frameskipping, if required */
   if ((update_frameskip || reinit) && !first_run)
     init_frameskip();

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -509,7 +509,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_left_border",
       "Hide Master System Left Border",
-      "TODO.",
+      "Cuts off 8 pixels from both the left and right side of the screen when running Master System games, thereby hiding the border seen on the left side of the screen",
       {
          { "disabled", NULL },
          { "enabled",  NULL },

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -507,6 +507,17 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "genesis_plus_gx_left_border",
+      "Hide Master System Left Border",
+      "TODO.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "genesis_plus_gx_aspect_ratio",
       "Core-Provided Aspect Ratio",
       "Choose the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",

--- a/libretro/osd.h
+++ b/libretro/osd.h
@@ -123,6 +123,7 @@ typedef struct
   uint8 ntsc;
   uint8 lcd;
   uint8 gg_extra;
+  uint8 left_border;
   uint8 render;
   t_input_config input[MAX_INPUTS];
   uint8 invert_mouse;


### PR DESCRIPTION
As discussed over here https://github.com/libretro/Genesis-Plus-GX/issues/218, This adds an option to hide the left border of Master System games by chopping off 8 pixels of both left and right sides of the screen:
<details>
<summary>Sonic The Hedgehog</summary>

![Sonic The Hedgehog (USA, Europe, Brazil)-210118-011427](https://user-images.githubusercontent.com/45218067/104860936-ed9fb800-592d-11eb-9688-91f462e26a6d.png)
![Sonic The Hedgehog (USA, Europe, Brazil)-210118-011437](https://user-images.githubusercontent.com/45218067/104860937-ed9fb800-592d-11eb-8d96-63047200c9d4.png)

</details>
This is somewhat different from how SMS-Plus-GX does, as I didn't know how to shift the screen without creating a black bar, but all by all it doesn't look bad, and of the games I've tested this out with, none seemed to make much use of the 8 rightmost pixels anyway:

<details>
<summary>Fantasy Zone</summary>

![Fantasy Zone (World)-210118-014316](https://user-images.githubusercontent.com/45218067/104861301-969ae280-592f-11eb-9cea-164b5ecf3ee9.png)
![Fantasy Zone (World)-210118-014325](https://user-images.githubusercontent.com/45218067/104861302-97337900-592f-11eb-9401-c94d767731a5.png)

</details>
<details>
<summary>Deep Duck Trouble Starring Donald Duck</summary>

![Deep Duck Trouble Starring Donald Duck (Europe, Brazil)-210118-014437](https://user-images.githubusercontent.com/45218067/104861391-f42f2f00-592f-11eb-87f7-87d941909517.png)
![Deep Duck Trouble Starring Donald Duck (Europe, Brazil)-210118-014447](https://user-images.githubusercontent.com/45218067/104861392-f4c7c580-592f-11eb-9f51-378f87b93d49.png)

</details>
<details>
<summary>Asterix and the Great Rescue</summary>

![Asterix and the Great Rescue (Europe, Brazil) (En,Fr,De,Es,It)-210118-014839](https://user-images.githubusercontent.com/45218067/104861406-08732c00-5930-11eb-82ef-de61b312e154.png)
![Asterix and the Great Rescue (Europe, Brazil) (En,Fr,De,Es,It)-210118-014851](https://user-images.githubusercontent.com/45218067/104861407-090bc280-5930-11eb-88ef-dde72740a5ac.png)

</details>
<details>
<summary>OutRun</summary>

![OutRun (World)-210118-014544](https://user-images.githubusercontent.com/45218067/104861433-22ad0a00-5930-11eb-8fbe-6ba50da410ad.png)
![OutRun (World)-210118-014555](https://user-images.githubusercontent.com/45218067/104861436-22ad0a00-5930-11eb-852b-ca67fe6d3aa8.png)

</details>
<details>
<summary>Prince of Persia</summary>

![Prince of Persia (Europe, Brazil)-210118-014712](https://user-images.githubusercontent.com/45218067/104861468-42443280-5930-11eb-8cd6-b25d7fbe1f75.png)
![Prince of Persia (Europe, Brazil)-210118-014723](https://user-images.githubusercontent.com/45218067/104861470-42dcc900-5930-11eb-847c-b384f468267e.png)

</details>