### PR TITLE
[Bugfix] Left border now remains hidden when loading a savestate

### DIFF
--- a/core/vdp_ctrl.c
+++ b/core/vdp_ctrl.c
@@ -342,6 +342,7 @@ void vdp_reset(void)
   }
   else if ((system_hw == SYSTEM_SMS || system_hw == SYSTEM_SMS2) && config.left_border)
   {
+    /* Horizontal display area reduced to 240 when hiding the left border */
     bitmap.viewport.x = (config.overscan & 2) ? 7 : -8;
     bitmap.viewport.y = (config.overscan & 1) * 24 * (vdp_pal + 1);
   }

--- a/core/vdp_ctrl.c
+++ b/core/vdp_ctrl.c
@@ -340,6 +340,11 @@ void vdp_reset(void)
     bitmap.viewport.x = (config.overscan & 2) ? 14 : -48;
     bitmap.viewport.y = (config.overscan & 1) ? (24 * (vdp_pal + 1)) : -24;
   }
+  else if ((system_hw == SYSTEM_SMS || system_hw == SYSTEM_SMS2) && config.left_border)
+  {
+    bitmap.viewport.x = (config.overscan & 2) ? 7 : -8;
+    bitmap.viewport.y = (config.overscan & 1) * 24 * (vdp_pal + 1);
+  }
   else
   {
     bitmap.viewport.x = (config.overscan & 2) * 7;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1191,12 +1191,7 @@ static bool update_viewport(void)
       else
          vwidth = SMS_NTSC_OUT_WIDTH(vwidth);
    }
-   
-   if ((system_hw == SYSTEM_SMS || system_hw == SYSTEM_SMS2) && config.left_border)
-   {
-	   bitmap.viewport.x = (config.overscan & 2) ? 7 : -8;
-   }
-
+ 
    if (config.render && interlaced)
    {
       vheight = vheight * 2;


### PR DESCRIPTION
Fixes the issue described here: https://github.com/libretro/Genesis-Plus-GX/pull/231#issuecomment-773964968