### PR TITLE
Remove 32bit Rpi4 platform since it's redundant.

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -161,8 +161,6 @@ ifneq (,$(findstring unix,$(platform)))
          PLATFORM_DEFINES += -DARM -marm -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
       else ifneq (,$(findstring rpi3,$(platform)))
          PLATFORM_DEFINES += -DARM -marm -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
-      else ifneq (,$(findstring rpi4,$(platform)))
-         PLATFORM_DEFINES += -DARM -marm -mcpu=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard
       else ifneq (,$(findstring rpi4_64,$(platform)))
          PLATFORM_DEFINES += -DARM -march=armv8-a+crc+simd -mtune=cortex-a72
       endif


### PR DESCRIPTION
This removes the rpi4 platform (which I originally added) because:

-For 32bit-mode rpi4, there is the rpi3 platform (rpi4 works on the same CPU mode as a Pi3 when booted in 32bit mode, AKA armhf).

-It was messing with rpi4_64 building, because make was finding the "rpi4" string and adding the flags on the "rpi4" platform, which caused the build to fail when "rpi4_64" was the specified platform.