### PR TITLE
Fix loading of content from archives

### DIFF
--- a/core/loadrom.c
+++ b/core/loadrom.c
@@ -572,8 +572,15 @@ int load_rom(char *filename)
   size = cdd_load(filename, (char *)(cart.rom));
   if (size < 0)
   {
-    /* error opening file */
-    return (0);
+    /* error opening file
+     * do not treat this as a fatal error, since
+     * we may be loading content from memory,
+     * rather than a physical file
+     * in this case we assume that the ROM is not
+     * a CD image, and pass responsibility for
+     * handling it to the platform-specific
+     * load_archive() function */
+    size = 0;
   }
 
   /* CD image file ? */

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -3072,7 +3072,7 @@ bool retro_load_game(const struct retro_game_info *info)
       strncpy(content_path, info->path, sizeof(content_path));
       content_path[sizeof(content_path) - 1] = '\0';
 
-      if (ext = strrchr(info->path, '.'))
+      if ((ext = strrchr(info->path, '.')))
       {
          strncpy(content_ext, ext + 1, sizeof(content_ext));
          content_ext[sizeof(content_ext) - 1] = '\0';


### PR DESCRIPTION
 #248 introduced a regression, causing load content failures when attempting to launch content from compressed files.

This happens because the core first attempts to load all files as CD images; it parses the content data, then falls back to normal ROM handling if a CD is not detected. In order to do this, it needs to read a physical file - when loading content from archives, this physical file does not exist.

I originally did not notice this issue because I had my sample compressed files in the same directory as the uncompressed source files. The way that paths are handled by the core, this meant that when I loaded a compressed file, the CD check was performed on the associated uncompressed copy - so content always loaded successfully....

This PR fixes the issue by disabling the CD image check when the frontend provides a valid content data buffer (since a buffer is only provided when loading non-CD content). It is an inelegant fix, but any other solution would require significant changes to the upstream code/API, which I believe should be avoided if possible.