### PR TITLE
Add RS-90 build target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -269,6 +269,12 @@ libretro-build-dingux-odbeta-mips32:
     - .libretro-dingux-odbeta-mips32-make-default
     - .core-defs
 
+# RS-90 OpenDingux Beta
+libretro-build-rs90-odbeta-mips32:
+  extends:
+    - .libretro-rs90-odbeta-mips32-make-default
+    - .core-defs
+
 #################################### MISC ##################################
 # Emscripten
 libretro-build-emscripten:

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -413,6 +413,20 @@ else ifeq ($(platform), emscripten)
    ENDIANNESS_DEFINES := -DLSB_FIRST -DALIGN_LONG -DBYTE_ORDER=LITTLE_ENDIAN -DHAVE_ZLIB
    STATIC_LINKING = 1
 
+# RS90
+else ifeq ($(platform), rs90)
+   TARGET := $(TARGET_NAME)_libretro.so
+   CC = /opt/rs90-toolchain/usr/bin/mipsel-linux-gcc
+   CXX = /opt/rs90-toolchain/usr/bin/mipsel-linux-g++
+   AR = /opt/rs90-toolchain/usr/bin/mipsel-linux-ar
+   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined
+   fpic := -fPIC
+   LDFLAGS += $(PTHREAD_FLAGS)
+   CFLAGS += $(PTHREAD_FLAGS) -G0
+   CFLAGS += -ffast-math -march=mips32 -mtune=mips32 -fomit-frame-pointer
+   ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN -DALIGN_LONG
+   USE_PER_SOUND_CHANNELS_CONFIG = 0
+
 # GCW0
 else ifeq ($(platform), gcw0)
    TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
This PR adds a Makefile + gitlab-ci.yml target for RS-90 devices.

The core is currently untested on this platform (I won't have access to the hardware for a week or so), but given the performance of other cores I would expect Game Gear and Master System content to run at full speed.

@john-parton Would you be willing to test this core?