### PR TITLE
Add 'LOW_MEMORY' build flag to force content loading from file on RAM-limited platforms

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -6,6 +6,7 @@ HAVE_SYS_PARAM = 1
 HOOK_CPU = 0
 HAVE_CDROM = 0
 USE_PER_SOUND_CHANNELS_CONFIG = 1
+LOW_MEMORY = 0
 
 CORE_DIR := .
 
@@ -426,6 +427,7 @@ else ifeq ($(platform), rs90)
    CFLAGS += -ffast-math -march=mips32 -mtune=mips32 -fomit-frame-pointer
    ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN -DALIGN_LONG
    USE_PER_SOUND_CHANNELS_CONFIG = 0
+   LOW_MEMORY = 1
 
 # GCW0
 else ifeq ($(platform), gcw0)
@@ -751,6 +753,10 @@ endif
 
 ifeq ($(USE_PER_SOUND_CHANNELS_CONFIG), 1)
 DEFINES += -DUSE_PER_SOUND_CHANNELS_CONFIG
+endif
+
+ifeq ($(LOW_MEMORY), 1)
+DEFINES += -DLOW_MEMORY
 endif
 
 CFLAGS += $(fpic) $(DEFINES) $(CODE_DEFINES) $(FLAGS)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2697,7 +2697,11 @@ void retro_set_environment(retro_environment_t cb)
    static const struct retro_system_content_info_override content_overrides[] = {
       {
          "mdx|md|smd|gen|bms|sms|gg|sg", /* extensions */
+#if defined(LOW_MEMORY)
+         true,                           /* need_fullpath */
+#else
          false,                          /* need_fullpath */
+#endif
          false                           /* persistent_data */
       },
       { NULL, false, false }
@@ -3023,12 +3027,16 @@ bool retro_load_game(const struct retro_game_info *info)
    content_path[0] = '\0';
    content_ext[0]  = '\0';
 
+   g_rom_data      = NULL;
+   g_rom_size      = 0;
+
    /* Attempt to fetch extended game info */
    if (environ_cb(RETRO_ENVIRONMENT_GET_GAME_INFO_EXT, &info_ext))
    {
+#if !defined(LOW_MEMORY)
       g_rom_data = (const void *)info_ext->data;
       g_rom_size = info_ext->size;
-
+#endif
       strncpy(g_rom_dir, info_ext->dir, sizeof(g_rom_dir));
       g_rom_dir[sizeof(g_rom_dir) - 1] = '\0';
 
@@ -3062,9 +3070,6 @@ bool retro_load_game(const struct retro_game_info *info)
 
       if (!info || !info->path)
          return false;
-
-      g_rom_data = NULL;
-      g_rom_size = 0;
 
       extract_directory(g_rom_dir, info->path, sizeof(g_rom_dir));
       extract_name(g_rom_name, info->path, sizeof(g_rom_name));


### PR DESCRIPTION
This PR adds a `LOW_MEMORY` build flag which forces the core to set `need_fullpath = true` - meaning that ROM data will be read directly from file rather than being passed as a frontend-provided data buffer. This is required for very low memory platforms, where the use of an 'external' memory buffer (which must be duplicated in the core) can exceed the total system RAM.

At present, this flag is only enabled for the RS-90 build. This allows 4MB ROMs to be loaded successfully (without the flag, the core will simply crash when attempting to launch such content)