### PR TITLE
Add core options v2 support

### DIFF
--- a/libretro/libretro-common/include/libretro.h
+++ b/libretro/libretro-common/include/libretro.h
@@ -1131,6 +1131,13 @@ enum retro_mod
                                             * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
                                             * This allows the core to additionally set option sublabel information
                                             * and/or provide localisation support.
+                                            *
+                                            * If version is >= 2, core options may instead be set by passing
+                                            * a retro_core_options_v2 struct to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+                                            * or an array of retro_core_options_v2 structs to
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL. This allows the core
+                                            * to additionally set optional core option category information
+                                            * for frontends with core option category support.
                                             */
 
 #define RETRO_ENVIRONMENT_SET_CORE_OPTIONS 53
@@ -1172,7 +1179,7 @@ enum retro_mod
                                             * default value is NULL, the first entry in the
                                             * retro_core_option_definition::values array is treated as the default.
                                             *
-                                            * The number of possible options should be very limited,
+                                            * The number of possible option values should be very limited,
                                             * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
                                             * i.e. it should be feasible to cycle through options
                                             * without a keyboard.
@@ -1205,6 +1212,7 @@ enum retro_mod
                                             * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
                                             * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
                                             * Afterwards it may be called again for the core to communicate
@@ -1491,6 +1499,217 @@ enum retro_mod
                                             *   the retro_game_info_ext array is guaranteed to have a
                                             *   size equal to the num_info argument passed to
                                             *   retro_load_game_special()
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 67
+                                           /* const struct retro_core_options_v2 * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 2.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            * If RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION returns an API
+                                            * version of >= 2, this callback is guaranteed to succeed
+                                            * (i.e. callback return value does not indicate success)
+                                            * If callback returns true, frontend has core option category
+                                            * support.
+                                            * If callback returns false, frontend does not have core option
+                                            * category support.
+                                            *
+                                            * 'data' points to a retro_core_options_v2 struct, containing
+                                            * of two pointers:
+                                            * - retro_core_options_v2::categories is an array of
+                                            *   retro_core_option_v2_category structs terminated by a
+                                            *   { NULL, NULL, NULL } element. If retro_core_options_v2::categories
+                                            *   is NULL, all core options will have no category and will be shown
+                                            *   at the top level of the frontend core option interface. If frontend
+                                            *   does not have core option category support, categories array will
+                                            *   be ignored.
+                                            * - retro_core_options_v2::definitions is an array of
+                                            *   retro_core_option_v2_definition structs terminated by a
+                                            *   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL }
+                                            *   element.
+                                            *
+                                            * >> retro_core_option_v2_category notes:
+                                            *
+                                            * - retro_core_option_v2_category::key should contain string
+                                            *   that uniquely identifies the core option category. Valid
+                                            *   key characters are [a-z, A-Z, 0-9, _, -]
+                                            *   Namespace collisions with other implementations' category
+                                            *   keys are permitted.
+                                            * - retro_core_option_v2_category::desc should contain a human
+                                            *   readable description of the category key.
+                                            * - retro_core_option_v2_category::info should contain any
+                                            *   additional human readable information text that a typical
+                                            *   user may need to understand the nature of the core option
+                                            *   category.
+                                            *
+                                            * Example entry:
+                                            * {
+                                            *     "advanced_settings",
+                                            *     "Advanced",
+                                            *     "Options affecting low-level emulation performance and accuracy."
+                                            * }
+                                            *
+                                            * >> retro_core_option_v2_definition notes:
+                                            *
+                                            * - retro_core_option_v2_definition::key should be namespaced to not
+                                            *   collide with other implementations' keys. e.g. A core called
+                                            *   'foo' should use keys named as 'foo_option'. Valid key characters
+                                            *   are [a-z, A-Z, 0-9, _, -].
+                                            * - retro_core_option_v2_definition::desc should contain a human readable
+                                            *   description of the key. Will be used when the frontend does not
+                                            *   have core option category support. Examples: "Aspect Ratio" or
+                                            *   "Video > Aspect Ratio".
+                                            * - retro_core_option_v2_definition::desc_categorized should contain a
+                                            *   human readable description of the key, which will be used when
+                                            *   frontend has core option category support. Example: "Aspect Ratio",
+                                            *   where associated retro_core_option_v2_category::desc is "Video".
+                                            *   If empty or NULL, the string specified by
+                                            *   retro_core_option_v2_definition::desc will be used instead.
+                                            *   retro_core_option_v2_definition::desc_categorized will be ignored
+                                            *   if retro_core_option_v2_definition::category_key is empty or NULL.
+                                            * - retro_core_option_v2_definition::info should contain any additional
+                                            *   human readable information text that a typical user may need to
+                                            *   understand the functionality of the option.
+                                            * - retro_core_option_v2_definition::info_categorized should contain
+                                            *   any additional human readable information text that a typical user
+                                            *   may need to understand the functionality of the option, and will be
+                                            *   used when frontend has core option category support. This is provided
+                                            *   to accommodate the case where info text references an option by
+                                            *   name/desc, and the desc/desc_categorized text for that option differ.
+                                            *   If empty or NULL, the string specified by
+                                            *   retro_core_option_v2_definition::info will be used instead.
+                                            *   retro_core_option_v2_definition::info_categorized will be ignored
+                                            *   if retro_core_option_v2_definition::category_key is empty or NULL.
+                                            * - retro_core_option_v2_definition::category_key should contain a
+                                            *   category identifier (e.g. "video" or "audio") that will be
+                                            *   assigned to the core option if frontend has core option category
+                                            *   support. A categorized option will be shown in a subsection/
+                                            *   submenu of the frontend core option interface. If key is empty
+                                            *   or NULL, or if key does not match one of the
+                                            *   retro_core_option_v2_category::key values in the associated
+                                            *   retro_core_option_v2_category array, option will have no category
+                                            *   and will be shown at the top level of the frontend core option
+                                            *   interface.
+                                            * - retro_core_option_v2_definition::values is an array of
+                                            *   retro_core_option_value structs terminated by a { NULL, NULL }
+                                            *   element.
+                                            * --> retro_core_option_v2_definition::values[index].value is an
+                                            *     expected option value.
+                                            * --> retro_core_option_v2_definition::values[index].label is a
+                                            *     human readable label used when displaying the value on screen.
+                                            *     If NULL, the value itself is used.
+                                            * - retro_core_option_v2_definition::default_value is the default
+                                            *   core option setting. It must match one of the expected option
+                                            *   values in the retro_core_option_v2_definition::values array. If
+                                            *   it does not, or the default value is NULL, the first entry in the
+                                            *   retro_core_option_v2_definition::values array is treated as the
+                                            *   default.
+                                            *
+                                            * The number of possible option values should be very limited,
+                                            * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
+                                            * i.e. it should be feasible to cycle through options
+                                            * without a keyboard.
+                                            *
+                                            * Example entries:
+                                            *
+                                            * - Uncategorized:
+                                            *
+                                            * {
+                                            *     "foo_option",
+                                            *     "Speed hack coprocessor X",
+                                            *     NULL,
+                                            *     "Provides increased performance at the expense of reduced accuracy.",
+                                            *     NULL,
+                                            *     NULL,
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * - Categorized:
+                                            *
+                                            * {
+                                            *     "foo_option",
+                                            *     "Advanced > Speed hack coprocessor X",
+                                            *     "Speed hack coprocessor X",
+                                            *     "Setting 'Advanced > Speed hack coprocessor X' to 'true' or 'Turbo' provides increased performance at the expense of reduced accuracy",
+                                            *     "Setting 'Speed hack coprocessor X' to 'true' or 'Turbo' provides increased performance at the expense of reduced accuracy",
+                                            *     "advanced_settings",
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * Only strings are operated on. The possible values will
+                                            * generally be displayed and stored as-is by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL 68
+                                           /* const struct retro_core_options_v2_intl * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 2.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            * If RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION returns an API
+                                            * version of >= 2, this callback is guaranteed to succeed
+                                            * (i.e. callback return value does not indicate success)
+                                            * If callback returns true, frontend has core option category
+                                            * support.
+                                            * If callback returns false, frontend does not have core option
+                                            * category support.
+                                            *
+                                            * This is fundamentally the same as RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+                                            * with the addition of localisation support. The description of the
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 callback should be consulted
+                                            * for further details.
+                                            *
+                                            * 'data' points to a retro_core_options_v2_intl struct.
+                                            *
+                                            * - retro_core_options_v2_intl::us is a pointer to a
+                                            *   retro_core_options_v2 struct defining the US English
+                                            *   core options implementation. It must point to a valid struct.
+                                            *
+                                            * - retro_core_options_v2_intl::local is a pointer to a
+                                            *   retro_core_options_v2 struct defining core options for
+                                            *   the current frontend language. It may be NULL (in which case
+                                            *   retro_core_options_v2_intl::us is used by the frontend). Any items
+                                            *   missing from this struct will be read from
+                                            *   retro_core_options_v2_intl::us instead.
+                                            *
+                                            * NOTE: Default core option values are always taken from the
+                                            * retro_core_options_v2_intl::us struct. Any default values in
+                                            * the retro_core_options_v2_intl::local struct will be ignored.
                                             */
 
 /* VFS functionality */
@@ -3212,6 +3431,124 @@ struct retro_core_options_intl
     * - Implementation for current frontend language
     * - May be NULL */
    struct retro_core_option_definition *local;
+};
+
+struct retro_core_option_v2_category
+{
+   /* Variable uniquely identifying the
+    * option category. Valid key characters
+    * are [a-z, A-Z, 0-9, _, -] */
+   const char *key;
+
+   /* Human-readable category description
+    * > Used as category menu label when
+    *   frontend has core option category
+    *   support */
+   const char *desc;
+
+   /* Human-readable category information
+    * > Used as category menu sublabel when
+    *   frontend has core option category
+    *   support
+    * > Optional (may be NULL or an empty
+    *   string) */
+   const char *info;
+};
+
+struct retro_core_option_v2_definition
+{
+   /* Variable to query in RETRO_ENVIRONMENT_GET_VARIABLE.
+    * Valid key characters are [a-z, A-Z, 0-9, _, -] */
+   const char *key;
+
+   /* Human-readable core option description
+    * > Used as menu label when frontend does
+    *   not have core option category support
+    *   e.g. "Video > Aspect Ratio" */
+   const char *desc;
+
+   /* Human-readable core option description
+    * > Used as menu label when frontend has
+    *   core option category support
+    *   e.g. "Aspect Ratio", where associated
+    *   retro_core_option_v2_category::desc
+    *   is "Video"
+    * > If empty or NULL, the string specified by
+    *   desc will be used as the menu label
+    * > Will be ignored (and may be set to NULL)
+    *   if category_key is empty or NULL */
+   const char *desc_categorized;
+
+   /* Human-readable core option information
+    * > Used as menu sublabel */
+   const char *info;
+
+   /* Human-readable core option information
+    * > Used as menu sublabel when frontend
+    *   has core option category support
+    *   (e.g. may be required when info text
+    *   references an option by name/desc,
+    *   and the desc/desc_categorized text
+    *   for that option differ)
+    * > If empty or NULL, the string specified by
+    *   info will be used as the menu sublabel
+    * > Will be ignored (and may be set to NULL)
+    *   if category_key is empty or NULL */
+   const char *info_categorized;
+
+   /* Variable specifying category (e.g. "video",
+    * "audio") that will be assigned to the option
+    * if frontend has core option category support.
+    * > Categorized options will be displayed in a
+    *   subsection/submenu of the frontend core
+    *   option interface
+    * > Specified string must match one of the
+    *   retro_core_option_v2_category::key values
+    *   in the associated retro_core_option_v2_category
+    *   array; If no match is not found, specified
+    *   string will be considered as NULL
+    * > If specified string is empty or NULL, option will
+    *   have no category and will be shown at the top
+    *   level of the frontend core option interface */
+   const char *category_key;
+
+   /* Array of retro_core_option_value structs, terminated by NULL */
+   struct retro_core_option_value values[RETRO_NUM_CORE_OPTION_VALUES_MAX];
+
+   /* Default core option value. Must match one of the values
+    * in the retro_core_option_value array, otherwise will be
+    * ignored */
+   const char *default_value;
+};
+
+struct retro_core_options_v2
+{
+   /* Array of retro_core_option_v2_category structs,
+    * terminated by NULL
+    * > If NULL, all entries in definitions array
+    *   will have no category and will be shown at
+    *   the top level of the frontend core option
+    *   interface
+    * > Will be ignored if frontend does not have
+    *   core option category support */
+   struct retro_core_option_v2_category *categories;
+
+   /* Array of retro_core_option_v2_definition structs,
+    * terminated by NULL */
+   struct retro_core_option_v2_definition *definitions;
+};
+
+struct retro_core_options_v2_intl
+{
+   /* Pointer to a retro_core_options_v2 struct
+    * > US English implementation
+    * > Must point to a valid struct */
+   struct retro_core_options_v2 *us;
+
+   /* Pointer to a retro_core_options_v2 struct
+    * - Implementation for current frontend language
+    * - May be NULL */
+   struct retro_core_options_v2 *local;
 };
 
 struct retro_game_info

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -13,9 +13,10 @@
 
 /*
  ********************************
- * VERSION: 1.3
+ * VERSION: 2.0
  ********************************
  *
+ * - 2.0: Add support for core options v2 interface
  * - 1.3: Move translations to libretro_core_options_intl.h
  *        - libretro_core_options_intl.h includes BOM and utf-8
  *          fix for MSVC 2010-2013
@@ -58,11 +59,48 @@ extern "C" {
  * - Will be used as a fallback for any missing entries in
  *   frontend language definition */
 
-struct retro_core_option_definition option_defs_us[] = {
+struct retro_core_option_v2_category option_cats_us[] = {
+   {
+      "system",
+      "System",
+      "Configure base hardware selection / region / BIOS / Sega CD save file parameters."
+   },
+   {
+      "video",
+      "Video",
+      "Configure aspect ratio / display cropping / video filter / frame skipping parameters."
+   },
+   {
+      "audio",
+      "Audio",
+      "Configure emulated audio devices."
+   },
+   {
+      "input",
+      "Input",
+      "Configure light gun / mouse input."
+   },
+   {
+      "hacks",
+      "Emulation Hacks",
+      "Configure processor overclocking and emulation accuracy parameters affecting low-level performance and compatibility."
+   },
+   {
+      "channel_volume",
+      "Advanced Channel Volume Settings",
+      "Configure the volume of individual hardware audio channels."
+   },
+   { NULL, NULL, NULL },
+};
+
+struct retro_core_option_v2_definition option_defs_us[] = {
    {
       "genesis_plus_gx_system_hw",
       "System Hardware",
+      NULL,
       "Runs loaded content with a specific emulated console. 'Auto' will select the most appropriate system for the current game.",
+      NULL,
+      "system",
       {
          { "auto",                 "Auto"               },
          { "sg-1000",              "SG-1000"            },
@@ -79,7 +117,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_region_detect",
       "System Region",
+      NULL,
       "Specify which region the system is from. For consoles other than the Game Gear, 'PAL' is 50hz while 'NTSC' is 60hz. Games may run faster or slower than normal if the incorrect region is selected.",
+      NULL,
+      "system",
       {
          { "auto",    "Auto"   },
          { "ntsc-u",  "NTSC-U" },
@@ -90,20 +131,12 @@ struct retro_core_option_definition option_defs_us[] = {
       "auto"
    },
    {
-      "genesis_plus_gx_force_dtack",
-      "System Lock-Ups",
-      "Emulate system lock-ups that occur on real hardware when performing illegal address access. This should only be disabled when playing certain demos and homebrew that rely on illegal behaviour for correct operation.",
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL },
-      },
-      "enabled"
-   },
-   {
       "genesis_plus_gx_bios",
       "System Boot ROM",
+      NULL,
       "Use official BIOS/bootloader for emulated hardware, if present in RetroArch's system directory. Displays console-specific start-up sequence/animation, then runs loaded content.",
+      NULL,
+      "system",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -114,7 +147,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_bram",
       "CD System BRAM",
+      NULL,
       "When running Sega CD content, specifies whether to share a single save file between all games from a specific region (Per-BIOS) or to create a separate save file for each game (Per-Game). Note that the Sega CD has limited internal storage, sufficient only for a handful of titles. To avoid running out of space, the 'Per-Game' setting is recommended.",
+      NULL,
+      "system",
       {
          { "per bios", "Per-BIOS" },
          { "per game", "Per-Game" },
@@ -123,20 +159,12 @@ struct retro_core_option_definition option_defs_us[] = {
       "per bios"
    },
    {
-      "genesis_plus_gx_addr_error",
-      "68K Address Error",
-      "The Genesis CPU (Motorola 68000) produces an Address Error (crash) when attempting to perform unaligned memory access. Enabling '68K Address Error' simulates this behaviour. It should only be disabled when playing ROM hacks, since these are typically developed using less accurate emulators and may rely on invalid RAM access for correct operation.",
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL },
-      },
-      "enabled"
-   },
-   {
       "genesis_plus_gx_lock_on",
       "Cartridge Lock-On",
+      NULL,
       "Lock-On Technology is a Genesis feature that allowed an older game to connect to the pass-through port of a special cartridge for extended or altered gameplay. This option specifies which type of special 'lock-on' cartridge to emulate. A corresponding bios file must be present in RetroArch's system directory.",
+      NULL,
+      "system",
       {
          { "disabled",            NULL },
          { "game genie",          "Game Genie" },
@@ -147,9 +175,158 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "genesis_plus_gx_aspect_ratio",
+      "Core-Provided Aspect Ratio",
+      NULL,
+      "Choose the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",
+      NULL,
+      "video",
+      {
+         { "auto",     "Auto" },
+         { "NTSC PAR", NULL },
+         { "PAL PAR",  NULL },
+      },
+      "auto"
+   },
+   {
+      "genesis_plus_gx_overscan",
+      "Borders",
+      NULL,
+      "Enable this to display the overscan regions at the top/bottom and/or left/right of the screen. These would normally be hidden by the bezel around the edge of a standard-definition television.",
+      NULL,
+      "video",
+      {
+         { "disabled",   NULL },
+         { "top/bottom", "Top/Bottom" },
+         { "left/right", "Left/Right" },
+         { "full",       "Full" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "genesis_plus_gx_left_border",
+      "Hide Master System Left Border",
+      NULL,
+      "Cuts off 8 pixels from both the left and right side of the screen when running Master System games, thereby hiding the border seen on the left side of the screen",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "genesis_plus_gx_gg_extra",
+      "Game Gear Extended Screen",
+      NULL,
+      "Forces Game Gear titles to run in 'SMS' mode, with an increased resolution of 256x192. May show additional content, but typically displays a border of corrupt/unwanted image data.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "genesis_plus_gx_blargg_ntsc_filter",
+      "Blargg NTSC Filter",
+      NULL,
+      "Apply a video filter to mimic various NTSC TV signals.",
+      NULL,
+      "video",
+      {
+         { "disabled",   NULL },
+         { "monochrome", "Monochrome" },
+         { "composite",  "Composite" },
+         { "svideo",     "S-Video" },
+         { "rgb",        "RGB" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "genesis_plus_gx_lcd_filter",
+      "LCD Ghosting Filter",
+      NULL,
+      "Apply an image 'ghosting' filter to mimic the display characteristics of the Game Gear and 'Genesis Nomad' LCD panels.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "genesis_plus_gx_render",
+      "Interlaced Mode 2 Output",
+      NULL,
+      "Interlaced Mode 2 allows the Genesis to output a double height (high resolution) 320x448 image by drawing alternate scanlines each frame (this is used by 'Sonic the Hedgehog 2' and 'Combat Cars' multiplayer modes). 'Double Field' mimics original hardware, producing a sharp image with flickering/interlacing artefacts. 'Single Field' apples a de-interlacing filter, which stabilises the image but causes mild blurring.",
+      NULL,
+      "video",
+      {
+         { "single field", "Single Field" },
+         { "double field", "Double Field" },
+         { NULL, NULL },
+      },
+      "single field"
+   },
+   {
+      "genesis_plus_gx_frameskip",
+      "Frameskip",
+      NULL,
+      "Skip frames to avoid audio buffer under-run (crackling). Improves performance at the expense of visual smoothness. 'Auto' skips frames when advised by the frontend. 'Manual' utilises the 'Frameskip Threshold (%)' setting.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "auto",     "Auto" },
+         { "manual",   "Manual" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "genesis_plus_gx_frameskip_threshold",
+      "Frameskip Threshold (%)",
+      NULL,
+      "When 'Frameskip' is set to 'Manual', specifies the audio buffer occupancy threshold (percentage) below which frames will be skipped. Higher values reduce the risk of crackling by causing frames to be dropped more frequently.",
+      NULL,
+      "video",
+      {
+         { "15", NULL },
+         { "18", NULL },
+         { "21", NULL },
+         { "24", NULL },
+         { "27", NULL },
+         { "30", NULL },
+         { "33", NULL },
+         { "36", NULL },
+         { "39", NULL },
+         { "42", NULL },
+         { "45", NULL },
+         { "48", NULL },
+         { "51", NULL },
+         { "54", NULL },
+         { "57", NULL },
+         { "60", NULL },
+         { NULL, NULL },
+      },
+      "33"
+   },
+   {
       "genesis_plus_gx_ym2413",
       "Master System FM (YM2413)",
+      NULL,
       "Enable emulation of the FM Sound Unit used by certain Sega Mark III/Master System games for enhanced audio output.",
+      NULL,
+      "audio",
       {
          { "auto",     "Auto" },
          { "disabled", NULL },
@@ -161,11 +338,14 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_ym2612",
       "Mega Drive / Genesis FM",
+      NULL,
 #ifdef HAVE_YM3438_CORE
       "Select method used to emulate the FM synthesizer (main sound generator) of the Mega Drive/Genesis. 'MAME' options are fast, and run full speed on most systems. 'Nuked' options are cycle accurate, very high quality, and have substantial CPU requirements. The 'YM2612' chip is used by the original Model 1 Genesis. The 'YM3438' is used in later Genesis revisions.",
 #else
       "Select method used to emulate the FM synthesizer (main sound generator) of the Mega Drive/Genesis. The 'YM2612' chip is used by the original Model 1 Genesis. The 'YM3438' is used in later Genesis revisions.",
 #endif
+      NULL,
+      "audio",
       {
          { "mame (ym2612)",          "MAME (YM2612)" },
          { "mame (asic ym3438)",     "MAME (ASIC YM3438)" },
@@ -181,7 +361,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_sound_output",
       "Sound Output",
+      NULL,
       "Select stereo or mono sound reproduction.",
+      NULL,
+      "audio",
       {
          { "stereo", "Stereo" },
          { "mono",   "Mono" },
@@ -190,9 +373,57 @@ struct retro_core_option_definition option_defs_us[] = {
       "stereo"
    },
    {
+      "genesis_plus_gx_audio_filter",
+      "Audio Filter",
+      NULL,
+      "Enable a low pass audio filter to better simulate the characteristic sound of a Model 1 Genesis.",
+      NULL,
+      "audio",
+      {
+         { "disabled", NULL },
+         { "low-pass", "Low-Pass" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "genesis_plus_gx_lowpass_range",
+      "Low-Pass Filter %",
+      NULL,
+      "Specify the cut-off frequency of the audio low pass filter. A higher value increases the perceived 'strength' of the filter, since a wider range of the high frequency spectrum is attenuated.",
+      NULL,
+      "audio",
+      {
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { "35", NULL },
+         { "40", NULL },
+         { "45", NULL },
+         { "50", NULL },
+         { "55", NULL },
+         { "60", NULL },
+         { "65", NULL },
+         { "70", NULL },
+         { "75", NULL },
+         { "80", NULL },
+         { "85", NULL },
+         { "90", NULL },
+         { "95", NULL },
+         { NULL, NULL },
+      },
+      "60"
+   },
+   {
       "genesis_plus_gx_psg_preamp",
       "PSG Preamp Level",
+      NULL,
       "Set the audio preamplifier level of the emulated SN76496 4-channel Programmable Sound Generator found in the Master System, Game Gear and Genesis.",
+      NULL,
+      "audio",
       {
          { "0",   NULL },
          { "5",   NULL },
@@ -242,7 +473,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_fm_preamp",
       "FM Preamp Level",
+      NULL,
       "Set the audio preamplifier level of the emulated Sega Mark III/Master System FM Sound Unit.",
+      NULL,
+      "audio",
       {
          { "0",   NULL },
          { "5",   NULL },
@@ -289,50 +523,14 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "100"
    },
-   {
-      "genesis_plus_gx_audio_filter",
-      "Audio Filter",
-      "Enable a low pass audio filter to better simulate the characteristic sound of a Model 1 Genesis.",
-      {
-         { "disabled", NULL },
-         { "low-pass", "Low-Pass" },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      "genesis_plus_gx_lowpass_range",
-      "Low-Pass Filter %",
-      "Specify the cut-off frequency of the audio low pass filter. A higher value increases the perceived 'strength' of the filter, since a wider range of the high frequency spectrum is attenuated.",
-      {
-         { "5",  NULL },
-         { "10", NULL },
-         { "15", NULL },
-         { "20", NULL },
-         { "25", NULL },
-         { "30", NULL },
-         { "35", NULL },
-         { "40", NULL },
-         { "45", NULL },
-         { "50", NULL },
-         { "55", NULL },
-         { "60", NULL },
-         { "65", NULL },
-         { "70", NULL },
-         { "75", NULL },
-         { "80", NULL },
-         { "85", NULL },
-         { "90", NULL },
-         { "95", NULL },
-         { NULL, NULL },
-      },
-      "60"
-   },
 #ifdef HAVE_EQ
    {
       "genesis_plus_gx_audio_eq_low",
       "EQ Low",
+      NULL,
       "Adjust the low range band of the internal audio equaliser.",
+      NULL,
+      "audio",
       {
          { "0",   NULL },
          { "5",   NULL },
@@ -362,7 +560,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_audio_eq_mid",
       "EQ Mid",
+      NULL,
       "Adjust the middle range band of the internal audio equaliser.",
+      NULL,
+      "audio",
       {
          { "0",   NULL },
          { "5",   NULL },
@@ -392,7 +593,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_audio_eq_high",
       "EQ High",
+      NULL,
       "Adjust the high range band of the internal audio equaliser.",
+      NULL,
+      "audio",
       {
          { "0",   NULL },
          { "5",   NULL },
@@ -421,139 +625,12 @@ struct retro_core_option_definition option_defs_us[] = {
    },
 #endif
    {
-      "genesis_plus_gx_frameskip",
-      "Frameskip",
-      "Skip frames to avoid audio buffer under-run (crackling). Improves performance at the expense of visual smoothness. 'Auto' skips frames when advised by the frontend. 'Manual' utilises the 'Frameskip Threshold (%)' setting.",
-      {
-         { "disabled", NULL },
-         { "auto",     "Auto" },
-         { "manual",   "Manual" },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      "genesis_plus_gx_frameskip_threshold",
-      "Frameskip Threshold (%)",
-      "When 'Frameskip' is set to 'Manual', specifies the audio buffer occupancy threshold (percentage) below which frames will be skipped. Higher values reduce the risk of crackling by causing frames to be dropped more frequently.",
-      {
-         { "15", NULL },
-         { "18", NULL },
-         { "21", NULL },
-         { "24", NULL },
-         { "27", NULL },
-         { "30", NULL },
-         { "33", NULL },
-         { "36", NULL },
-         { "39", NULL },
-         { "42", NULL },
-         { "45", NULL },
-         { "48", NULL },
-         { "51", NULL },
-         { "54", NULL },
-         { "57", NULL },
-         { "60", NULL },
-         { NULL, NULL },
-      },
-      "33"
-   },
-   {
-      "genesis_plus_gx_blargg_ntsc_filter",
-      "Blargg NTSC Filter",
-      "Apply a video filter to mimic various NTSC TV signals.",
-      {
-         { "disabled",   NULL },
-         { "monochrome", "Monochrome" },
-         { "composite",  "Composite" },
-         { "svideo",     "S-Video" },
-         { "rgb",        "RGB" },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      "genesis_plus_gx_lcd_filter",
-      "LCD Ghosting Filter",
-      "Apply an image 'ghosting' filter to mimic the display characteristics of the Game Gear and 'Genesis Nomad' LCD panels.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      "genesis_plus_gx_overscan",
-      "Borders",
-      "Enable this to display the overscan regions at the top/bottom and/or left/right of the screen. These would normally be hidden by the bezel around the edge of a standard-definition television.",
-      {
-         { "disabled",   NULL },
-         { "top/bottom", "Top/Bottom" },
-         { "left/right", "Left/Right" },
-         { "full",       "Full" },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      "genesis_plus_gx_gg_extra",
-      "Game Gear Extended Screen",
-      "Forces Game Gear titles to run in 'SMS' mode, with an increased resolution of 256x192. May show additional content, but typically displays a border of corrupt/unwanted image data.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      "genesis_plus_gx_left_border",
-      "Hide Master System Left Border",
-      "Cuts off 8 pixels from both the left and right side of the screen when running Master System games, thereby hiding the border seen on the left side of the screen",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      "genesis_plus_gx_aspect_ratio",
-      "Core-Provided Aspect Ratio",
-      "Choose the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",
-      {
-         { "auto",     "Auto" },
-         { "NTSC PAR", NULL },
-         { "PAL PAR",  NULL },
-      },
-      "auto"
-   },
-   {
-      "genesis_plus_gx_render",
-      "Interlaced Mode 2 Output",
-      "Interlaced Mode 2 allows the Genesis to output a double height (high resolution) 320x448 image by drawing alternate scanlines each frame (this is used by 'Sonic the Hedgehog 2' and 'Combat Cars' multiplayer modes). 'Double Field' mimics original hardware, producing a sharp image with flickering/interlacing artefacts. 'Single Field' apples a de-interlacing filter, which stabilises the image but causes mild blurring.",
-      {
-         { "single field", "Single Field" },
-         { "double field", "Double Field" },
-         { NULL, NULL },
-      },
-      "single field"
-   },
-   {
-      "genesis_plus_gx_gun_cursor",
-      "Show Light Gun Crosshair",
-      "Display light gun crosshairs when using the 'MD Menacer', 'MD Justifiers' and 'MS Light Phaser' input device types.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
       "genesis_plus_gx_gun_input",
       "Light Gun Input",
+      NULL,
       "Use a mouse-controlled 'Light Gun' or 'Touchscreen' input.",
+      NULL,
+      "input",
       {
          { "lightgun",    "Light Gun" },
          { "touchscreen", "Touchscreen" },
@@ -562,9 +639,40 @@ struct retro_core_option_definition option_defs_us[] = {
       "lightgun"
    },
    {
+      "genesis_plus_gx_gun_cursor",
+      "Show Light Gun Crosshair",
+      NULL,
+      "Display light gun crosshairs when using the 'MD Menacer', 'MD Justifiers' and 'MS Light Phaser' input device types.",
+      NULL,
+      "input",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "genesis_plus_gx_invert_mouse",
       "Invert Mouse Y-Axis",
+      NULL,
       "Inverts the Y-axis of the 'MD Mouse' input device type.",
+      NULL,
+      "input",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "genesis_plus_gx_no_sprite_limit",
+      "Remove Per-Line Sprite Limit",
+      NULL,
+      "Removes the 8 (Master System) or 20 (Genesis) sprite-per-scanline hardware limit. This reduces flickering but can cause visual glitches, as some games exploit the hardware limit to generate special effects.",
+      NULL,
+      "hacks",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -576,7 +684,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_overclock",
       "CPU Speed",
+      NULL,
       "Overclock the emulated CPU. Can reduce slowdown, but may cause glitches.",
+      NULL,
+      "hacks",
       {
          { "100%", NULL },
          { "125%", NULL },
@@ -589,21 +700,41 @@ struct retro_core_option_definition option_defs_us[] = {
    },
 #endif
    {
-      "genesis_plus_gx_no_sprite_limit",
-      "Remove Per-Line Sprite Limit",
-      "Removes the 8 (Master System) or 20 (Genesis) sprite-per-scanline hardware limit. This reduces flickering but can cause visual glitches, as some games exploit the hardware limit to generate special effects.",
+      "genesis_plus_gx_force_dtack",
+      "System Lock-Ups",
+      NULL,
+      "Emulate system lock-ups that occur on real hardware when performing illegal address access. This should only be disabled when playing certain demos and homebrew that rely on illegal behaviour for correct operation.",
+      NULL,
+      "hacks",
       {
-         { "disabled", NULL },
          { "enabled",  NULL },
+         { "disabled", NULL },
          { NULL, NULL },
       },
-      "disabled"
+      "enabled"
+   },
+   {
+      "genesis_plus_gx_addr_error",
+      "68K Address Error",
+      NULL,
+      "The Genesis CPU (Motorola 68000) produces an Address Error (crash) when attempting to perform unaligned memory access. Enabling '68K Address Error' simulates this behaviour. It should only be disabled when playing ROM hacks, since these are typically developed using less accurate emulators and may rely on invalid RAM access for correct operation.",
+      NULL,
+      "hacks",
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
    },
 #ifdef USE_PER_SOUND_CHANNELS_CONFIG
    {
       "genesis_plus_gx_show_advanced_audio_settings",
       "Show Advanced Audio Volume Settings (Reopen menu)",
+      NULL,
       "Enable configuration of low-level audio channel parameters. NOTE: Quick Menu must be toggled for this setting to take effect.",
+      NULL,
+      "channel_volume",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
@@ -614,7 +745,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_psg_channel_0_volume",
       "PSG Tone Channel 0 Volume %",
+      NULL,
       "Reduce the volume of the PSG Tone Channel 0.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -634,7 +768,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_psg_channel_1_volume",
       "PSG Tone Channel 1 Volume %",
+      NULL,
       "Reduce the volume of the PSG Tone Channel 1.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -654,7 +791,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_psg_channel_2_volume",
       "PSG Tone Channel 2 Volume %",
+      NULL,
       "Reduce the volume of the PSG Tone Channel 2.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -674,7 +814,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_psg_channel_3_volume",
       "PSG Noise Channel 3 Volume %",
+      NULL,
       "Reduce the volume of the PSG Noise Channel 3.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -694,7 +837,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_md_channel_0_volume",
       "Mega Drive / Genesis FM Channel 0 Volume %",
+      NULL,
       "Reduce the volume of the Mega Drive / Genesis FM Channel 0. Only works with MAME FM emulators.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -714,7 +860,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_md_channel_1_volume",
       "Mega Drive / Genesis FM Channel 1 Volume %",
+      NULL,
       "Reduce the volume of the Mega Drive / Genesis FM Channel 1. Only works with MAME FM emulators.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -734,7 +883,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_md_channel_2_volume",
       "Mega Drive / Genesis FM Channel 2 Volume %",
+      NULL,
       "Reduce the volume of the Mega Drive / Genesis FM Channel 2. Only works with MAME FM emulators.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -754,7 +906,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_md_channel_3_volume",
       "Mega Drive / Genesis FM Channel 3 Volume %",
+      NULL,
       "Reduce the volume of the Mega Drive / Genesis FM Channel 3. Only works with MAME FM emulators.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -774,7 +929,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_md_channel_4_volume",
       "Mega Drive / Genesis FM Channel 4 Volume %",
+      NULL,
       "Reduce the volume of the Mega Drive / Genesis FM Channel 4. Only works with MAME FM emulators.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -794,7 +952,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_md_channel_5_volume",
       "Mega Drive / Genesis FM Channel 5 Volume %",
+      NULL,
       "Reduce the volume of the Mega Drive / Genesis FM Channel 5. Only works with MAME FM emulators.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -814,7 +975,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_sms_fm_channel_0_volume",
       "Master System FM (YM2413) Channel 0 Volume %",
+      NULL,
       "Reduce the volume of the Master System FM Channel 0.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -834,7 +998,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_sms_fm_channel_1_volume",
       "Master System FM (YM2413) Channel 1 Volume %",
+      NULL,
       "Reduce the volume of the Master System FM Channel 1.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -854,7 +1021,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_sms_fm_channel_2_volume",
       "Master System FM (YM2413) Channel 2 Volume %",
+      NULL,
       "Reduce the volume of the Master System FM Channel 2.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -874,7 +1044,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_sms_fm_channel_3_volume",
       "Master System FM (YM2413) Channel 3 Volume %",
+      NULL,
       "Reduce the volume of the Master System FM Channel 3.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -894,7 +1067,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_sms_fm_channel_4_volume",
       "Master System FM (YM2413) Channel 4 Volume %",
+      NULL,
       "Reduce the volume of the Master System FM Channel 4.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -914,7 +1090,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_sms_fm_channel_5_volume",
       "Master System FM (YM2413) Channel 5 Volume %",
+      NULL,
       "Reduce the volume of the Master System FM Channel 5.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -934,7 +1113,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_sms_fm_channel_6_volume",
       "Master System FM (YM2413) Channel 6 Volume %",
+      NULL,
       "Reduce the volume of the Master System FM Channel 6.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -954,7 +1136,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_sms_fm_channel_7_volume",
       "Master System FM (YM2413) Channel 7 Volume %",
+      NULL,
       "Reduce the volume of the Master System FM Channel 7.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -974,7 +1159,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "genesis_plus_gx_sms_fm_channel_8_volume",
       "Master System FM (YM2413) Channel 8 Volume %",
+      NULL,
       "Reduce the volume of the Master System FM Channel 8.",
+      NULL,
+      "channel_volume",
       {
          { "0",   NULL },
          { "10",  NULL },
@@ -992,7 +1180,12 @@ struct retro_core_option_definition option_defs_us[] = {
       "100"
    },
 #endif
-   { NULL, NULL, NULL, {{0}}, NULL },
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+
+struct retro_core_options_v2 options_us = {
+   option_cats_us,
+   option_defs_us
 };
 
 /*
@@ -1002,15 +1195,15 @@ struct retro_core_option_definition option_defs_us[] = {
 */
 
 #ifndef HAVE_NO_LANGEXTRA
-struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
-   option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
+struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST] = {
+   &options_us,    /* RETRO_LANGUAGE_ENGLISH */
    NULL,           /* RETRO_LANGUAGE_JAPANESE */
    NULL,           /* RETRO_LANGUAGE_FRENCH */
    NULL,           /* RETRO_LANGUAGE_SPANISH */
    NULL,           /* RETRO_LANGUAGE_GERMAN */
    NULL,           /* RETRO_LANGUAGE_ITALIAN */
    NULL,           /* RETRO_LANGUAGE_DUTCH */
-   option_defs_pt_br, /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   &options_pt_br, /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
    NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
    NULL,           /* RETRO_LANGUAGE_RUSSIAN */
    NULL,           /* RETRO_LANGUAGE_KOREAN */
@@ -1021,7 +1214,12 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
    NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
    NULL,           /* RETRO_LANGUAGE_ARABIC */
    NULL,           /* RETRO_LANGUAGE_GREEK */
-   option_defs_tr, /* RETRO_LANGUAGE_TURKISH */
+   &options_tr,    /* RETRO_LANGUAGE_TURKISH */
+   NULL,           /* RETRO_LANGUAGE_SLOVAK */
+   NULL,           /* RETRO_LANGUAGE_PERSIAN */
+   NULL,           /* RETRO_LANGUAGE_HEBREW */
+   NULL,           /* RETRO_LANGUAGE_ASTURIAN */
+   NULL,           /* RETRO_LANGUAGE_FINNISH */
 };
 #endif
 
@@ -1039,39 +1237,61 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
  *   be as painless as possible for core devs)
  */
 
-INLINE void libretro_set_core_options(retro_environment_t environ_cb)
+INLINE void libretro_set_core_options(retro_environment_t environ_cb,
+      bool *categories_supported)
 {
-   unsigned version = 0;
+   unsigned version  = 0;
+#ifndef HAVE_NO_LANGEXTRA
+   unsigned language = 0;
+#endif
 
-   if (!environ_cb)
+   if (!environ_cb || !categories_supported)
       return;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
+   *categories_supported = false;
+
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))
+      version = 0;
+
+   if (version >= 2)
    {
 #ifndef HAVE_NO_LANGEXTRA
-      struct retro_core_options_intl core_options_intl;
-      unsigned language = 0;
+      struct retro_core_options_v2_intl core_options_intl;
 
-      core_options_intl.us    = option_defs_us;
+      core_options_intl.us    = &options_us;
       core_options_intl.local = NULL;
 
       if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
           (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
-         core_options_intl.local = option_defs_intl[language];
+         core_options_intl.local = options_intl[language];
 
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL,
+            &core_options_intl);
 #else
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, &option_defs_us);
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+            &options_us);
 #endif
    }
    else
    {
-      size_t i;
+      size_t i, j;
+      size_t option_index              = 0;
       size_t num_options               = 0;
+      struct retro_core_option_definition
+            *option_v1_defs_us         = NULL;
+#ifndef HAVE_NO_LANGEXTRA
+      size_t num_options_intl          = 0;
+      struct retro_core_option_v2_definition
+            *option_defs_intl          = NULL;
+      struct retro_core_option_definition
+            *option_v1_defs_intl       = NULL;
+      struct retro_core_options_intl
+            core_options_v1_intl;
+#endif
       struct retro_variable *variables = NULL;
       char **values_buf                = NULL;
 
-      /* Determine number of options */
+      /* Determine total number of options */
       while (true)
       {
          if (option_defs_us[num_options].key)
@@ -1080,86 +1300,192 @@ INLINE void libretro_set_core_options(retro_environment_t environ_cb)
             break;
       }
 
-      /* Allocate arrays */
-      variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
-      values_buf = (char **)calloc(num_options, sizeof(char *));
-
-      if (!variables || !values_buf)
-         goto error;
-
-      /* Copy parameters from option_defs_us array */
-      for (i = 0; i < num_options; i++)
+      if (version >= 1)
       {
-         const char *key                        = option_defs_us[i].key;
-         const char *desc                       = option_defs_us[i].desc;
-         const char *default_value              = option_defs_us[i].default_value;
-         struct retro_core_option_value *values = option_defs_us[i].values;
-         size_t buf_len                         = 3;
-         size_t default_index                   = 0;
+         /* Allocate US array */
+         option_v1_defs_us = (struct retro_core_option_definition *)
+               calloc(num_options + 1, sizeof(struct retro_core_option_definition));
 
-         values_buf[i] = NULL;
-
-         if (desc)
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
          {
-            size_t num_values = 0;
+            struct retro_core_option_v2_definition *option_def_us = &option_defs_us[i];
+            struct retro_core_option_value *option_values         = option_def_us->values;
+            struct retro_core_option_definition *option_v1_def_us = &option_v1_defs_us[i];
+            struct retro_core_option_value *option_v1_values      = option_v1_def_us->values;
 
-            /* Determine number of values */
+            option_v1_def_us->key           = option_def_us->key;
+            option_v1_def_us->desc          = option_def_us->desc;
+            option_v1_def_us->info          = option_def_us->info;
+            option_v1_def_us->default_value = option_def_us->default_value;
+
+            /* Values must be copied individually... */
+            while (option_values->value)
+            {
+               option_v1_values->value = option_values->value;
+               option_v1_values->label = option_values->label;
+
+               option_values++;
+               option_v1_values++;
+            }
+         }
+
+#ifndef HAVE_NO_LANGEXTRA
+         if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+             (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH) &&
+             options_intl[language])
+            option_defs_intl = options_intl[language]->definitions;
+
+         if (option_defs_intl)
+         {
+            /* Determine number of intl options */
             while (true)
             {
-               if (values[num_values].value)
-               {
-                  /* Check if this is the default value */
-                  if (default_value)
-                     if (strcmp(values[num_values].value, default_value) == 0)
-                        default_index = num_values;
-
-                  buf_len += strlen(values[num_values].value);
-                  num_values++;
-               }
+               if (option_defs_intl[num_options_intl].key)
+                  num_options_intl++;
                else
                   break;
             }
 
-            /* Build values string */
-            if (num_values > 0)
+            /* Allocate intl array */
+            option_v1_defs_intl = (struct retro_core_option_definition *)
+                  calloc(num_options_intl + 1, sizeof(struct retro_core_option_definition));
+
+            /* Copy parameters from option_defs_intl array */
+            for (i = 0; i < num_options_intl; i++)
             {
-               size_t j;
+               struct retro_core_option_v2_definition *option_def_intl = &option_defs_intl[i];
+               struct retro_core_option_value *option_values           = option_def_intl->values;
+               struct retro_core_option_definition *option_v1_def_intl = &option_v1_defs_intl[i];
+               struct retro_core_option_value *option_v1_values        = option_v1_def_intl->values;
 
-               buf_len += num_values - 1;
-               buf_len += strlen(desc);
+               option_v1_def_intl->key           = option_def_intl->key;
+               option_v1_def_intl->desc          = option_def_intl->desc;
+               option_v1_def_intl->info          = option_def_intl->info;
+               option_v1_def_intl->default_value = option_def_intl->default_value;
 
-               values_buf[i] = (char *)calloc(buf_len, sizeof(char));
-               if (!values_buf[i])
-                  goto error;
-
-               strcpy(values_buf[i], desc);
-               strcat(values_buf[i], "; ");
-
-               /* Default value goes first */
-               strcat(values_buf[i], values[default_index].value);
-
-               /* Add remaining values */
-               for (j = 0; j < num_values; j++)
+               /* Values must be copied individually... */
+               while (option_values->value)
                {
-                  if (j != default_index)
-                  {
-                     strcat(values_buf[i], "|");
-                     strcat(values_buf[i], values[j].value);
-                  }
+                  option_v1_values->value = option_values->value;
+                  option_v1_values->label = option_values->label;
+
+                  option_values++;
+                  option_v1_values++;
                }
             }
          }
 
-         variables[i].key   = key;
-         variables[i].value = values_buf[i];
+         core_options_v1_intl.us    = option_v1_defs_us;
+         core_options_v1_intl.local = option_v1_defs_intl;
+
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_v1_intl);
+#else
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, option_v1_defs_us);
+#endif
+      }
+      else
+      {
+         /* Allocate arrays */
+         variables  = (struct retro_variable *)calloc(num_options + 1,
+               sizeof(struct retro_variable));
+         values_buf = (char **)calloc(num_options, sizeof(char *));
+
+         if (!variables || !values_buf)
+            goto error;
+
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            const char *key                        = option_defs_us[i].key;
+            const char *desc                       = option_defs_us[i].desc;
+            const char *default_value              = option_defs_us[i].default_value;
+            struct retro_core_option_value *values = option_defs_us[i].values;
+            size_t buf_len                         = 3;
+            size_t default_index                   = 0;
+
+            values_buf[i] = NULL;
+
+            /* Skip options that are irrelevant when using the
+             * old style core options interface */
+            if (strcmp(key, "genesis_plus_gx_show_advanced_audio_settings") == 0)
+               continue;
+
+            if (desc)
+            {
+               size_t num_values = 0;
+
+               /* Determine number of values */
+               while (true)
+               {
+                  if (values[num_values].value)
+                  {
+                     /* Check if this is the default value */
+                     if (default_value)
+                        if (strcmp(values[num_values].value, default_value) == 0)
+                           default_index = num_values;
+
+                     buf_len += strlen(values[num_values].value);
+                     num_values++;
+                  }
+                  else
+                     break;
+               }
+
+               /* Build values string */
+               if (num_values > 0)
+               {
+                  buf_len += num_values - 1;
+                  buf_len += strlen(desc);
+
+                  values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+                  if (!values_buf[i])
+                     goto error;
+
+                  strcpy(values_buf[i], desc);
+                  strcat(values_buf[i], "; ");
+
+                  /* Default value goes first */
+                  strcat(values_buf[i], values[default_index].value);
+
+                  /* Add remaining values */
+                  for (j = 0; j < num_values; j++)
+                  {
+                     if (j != default_index)
+                     {
+                        strcat(values_buf[i], "|");
+                        strcat(values_buf[i], values[j].value);
+                     }
+                  }
+               }
+            }
+
+            variables[option_index].key   = key;
+            variables[option_index].value = values_buf[i];
+            option_index++;
+         }
+
+         /* Set variables */
+         environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
       }
 
-      /* Set variables */
-      environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
-
 error:
-
       /* Clean up */
+
+      if (option_v1_defs_us)
+      {
+         free(option_v1_defs_us);
+         option_v1_defs_us = NULL;
+      }
+
+#ifndef HAVE_NO_LANGEXTRA
+      if (option_v1_defs_intl)
+      {
+         free(option_v1_defs_intl);
+         option_v1_defs_intl = NULL;
+      }
+#endif
+
       if (values_buf)
       {
          for (i = 0; i < num_options; i++)

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -51,108 +51,150 @@ extern "C" {
 
 /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
 
-struct retro_core_option_definition option_defs_pt_br[] = {
+struct retro_core_option_v2_category option_cats_pt_br[] = {
+   {
+      "system",
+      NULL,
+      NULL
+   },
+   {
+      "video",
+      NULL,
+      NULL
+   },
+   {
+      "audio",
+      NULL,
+      NULL
+   },
+   {
+      "input",
+      NULL,
+      NULL
+   },
+   {
+      "hacks",
+      NULL,
+      NULL
+   },
+   {
+      "channel_volume",
+      NULL,
+      NULL
+   },
+   { NULL, NULL, NULL },
+};
+
+struct retro_core_option_v2_definition option_defs_pt_br[] = {
    {
       "genesis_plus_gx_system_hw",
       "Hardware do sistema",
+      NULL,
       "Executa o conteúdo carregado com um console emulado específico. 'Automático' selecionará o sistema mais apropriado para o jogo atual.",
+      NULL,
+      NULL,
       {
-         { "auto",                 NULL },
-         { "sg-1000",              "SG-1000"            },
-         { "sg-1000 II",           "SG-1000 II"         },
-         { "mark-III",             "Mark III"           },
-         { "master system",        "Master System"      },
-         { "master system II",     "Master System II"   },
-         { "game gear",            "Game Gear"          },
-         { "mega drive / genesis", "Mega Drive" },
          { NULL, NULL },
       },
-      "auto"
+      NULL
    },
    {
       "genesis_plus_gx_region_detect",
       "Região do sistema",
+      NULL,
       "Especifica de que região o sistema é. Para consoles que não sejam o Game Gear, 'PAL' é de 50hz enquanto 'NTSC' é de 60hz. s jogos podem ser executados mais rapidamente ou mais lentamente do que o normal se a região incorreta estiver selecionada.",
+      NULL,
+      NULL,
       {
-         { "auto",    NULL },
-         { "ntsc-u",  "NTSC-U" },
-         { "pal",     "PAL"    },
-         { "ntsc-j",  "NTSC-J" },
          { NULL, NULL },
       },
-      "auto"
+      NULL
    },
    {
       "genesis_plus_gx_force_dtack",
       "Bloqueios do sistema",
+      NULL,
       "Emula os bloqueios do sistema que ocorrem no hardware real ao executar acesso ilegal a endereços. Isso só deve ser desativado ao reproduzir certas demos e homebrews que dependem de comportamento ilegal para a operação correta.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "genesis_plus_gx_bios",
       "ROM de inicialização do sistema",
+      NULL,
       "Usa a BIOS/bootloader oficial para o hardware emulado, se estiver presente no diretório de sistema do RetroArch. Exibe a sequência/animação da inicialização específica do console e executa o conteúdo carregado.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_bram",
       "Sistema BRAM do CD",
+      NULL,
       "Ao executar o conteúdo de CD da Sega, especifica se um único arquivo salvo será salvo entre todos os jogos de uma região específica (Por-BIOS) ou se será criado um arquivo salvo separado para cada jogo (Por-Jogo). Observe que o CD da Sega possui armazenamento interno limitado, suficiente apenas para alguns títulos. Para evitar ficar sem espaço, a configuração 'Por jogo' é recomendada.",
+      NULL,
+      NULL,
       {
          { "per bios", "Por-BIOS" },
          { "per game", "Por-Jogo" },
          { NULL, NULL },
       },
-      "per bios"
+      NULL
    },
    {
       "genesis_plus_gx_addr_error",
       "Erro de endereçamento do 68K",
+      NULL,
       "A CPU do Mega Drive (Motorola 68000) produz um erro de endereçamento (falha) ao tentar executar o acesso desalinhado à memória. A ativação do 'Erro de endereçamento do 68K' simula esse comportamento. Ele deve ser desativado apenas durante a execução de hacks de ROMs, pois geralmente são desenvolvidos usando emuladores menos precisos e podem contar com acesso inválido à RAM para a operação correta.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "genesis_plus_gx_lock_on",
       "Cartucho Lock-On",
+      NULL,
       "A tecnologia Lock-On é um recurso do Mega Drive que permite que um jogo mais antigo se conecte à porta de passagem de um cartucho especial para uma jogabilidade estendida ou alterada. Esta opção especifica qual tipo de cartucho especial 'lock-on' a ser emulado. Um arquivo do BIOS correspondente deve estar presente no diretório do sistema do RetroArch.",
+      NULL,
+      NULL,
       {
-         { "disabled",            NULL },
-         { "game genie",          "Game Genie" },
-         { "action replay (pro)", "Action Replay (Pro)" },
-         { "sonic & knuckles",    "Sonic & Knuckles" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_ym2413",
       "Som FM do Master System (YM2413)",
+      NULL,
       "Ativa a emulação da unidade de som FM usada por certos jogos do Master System para obter uma saída de áudio aprimorada.",
+      NULL,
+      NULL,
       {
-         { "auto",     NULL },
-         { "disabled", NULL },
-         { "enabled",  NULL },
          { NULL, NULL },
       },
-      "auto"
+      NULL
    },
    {
       "genesis_plus_gx_ym2612",
       "Som FM do Mega Drive",
+      NULL,
 #ifdef HAVE_YM3438_CORE
       "Seleciona o método usado para emular o sintetizador FM (gerador de som principal) do Mega Drive. As opções 'MAME' são rápidas e executam a toda velocidade na maioria dos sistemas. As opções 'Nuked' têm precisão de ciclo, qualidade muito alta e requisitos substanciais de CPU. O chip 'YM2612' é usado pelo Mega Drive Modelo 1 original. O 'YM3438' é usado em revisões posteriores do Mega Drive.",
 #else
       "Seleciona o método usado para emular o sintetizador de FM (gerador de som principal) do Mega Drive. O chip 'YM2612' é usado pelo Mega Drive Modelo 1 original. O 'YM3438' é usado em revisões posteriores do Mega Drive.",
 #endif
+      NULL,
+      NULL,
       {
          { "mame (ym2612)",          "MAME (YM2612)" },
          { "mame (asic ym3438)",     "MAME (ASIC YM3438)" },
@@ -163,108 +205,141 @@ struct retro_core_option_definition option_defs_pt_br[] = {
 #endif
          { NULL, NULL },
       },
-      "mame (ym2612)"
+      NULL
    },
    {
       "genesis_plus_gx_sound_output",
       "Saída de som",
+      NULL,
       "Selecione reprodução de som estéreo ou mono.",
+      NULL,
+      NULL,
       {
          { "stereo", "Estéreo" },
          { "mono",   "Mono" },
          { NULL, NULL },
       },
-      "stereo"
+      NULL
    },
    {
       "genesis_plus_gx_psg_preamp",
       "Nível de pré-amplificação do PSG",
+      NULL,
       "Define o nível de pré-amplificação do áudio do Gerador de Som Programável (PSG) de 4 canais SN76496 emulado encontrado no Master System, Game Gear e Mega Drive.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "150"
+      NULL
    },
    {
       "genesis_plus_gx_fm_preamp",
       "Nível de pré-amplificação do FM",
+      NULL,
       "Define o nível de pré-amplificação de áudio da Unidade de Som FM emulada do Master System.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_audio_filter",
       "Filtro de áudio",
+      NULL,
       "Ativa um filtro de áudio passa-baixo para simular melhor o som característico de um Mega Drive Modelo 1.",
+      NULL,
+      NULL,
       {
          { "disabled", NULL },
          { "low-pass", "Passa-baixo" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_lowpass_range",
       "Filtro passa-baixo %",
+      NULL,
       "Especifica a frequência de corte do filtro de áudio passa-baixo. Um valor mais alto aumenta a 'força' percebida do filtro, uma vez que uma faixa mais ampla do espectro de alta frequência é atenuada.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "60"
+      NULL
    },
 #ifdef HAVE_EQ
    {
       "genesis_plus_gx_audio_eq_low",
       "EQ baixa",
+      NULL,
       "Ajuste a banda de alcance baixo do equalizador de áudio interno.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_audio_eq_mid",
       "EQ média",
+      NULL,
       "Ajuste a banda de alcance média do equalizador de áudio interno.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_audio_eq_high",
       "EQ alta",
+      NULL,
       "Ajuste a banda de alcance alta do equalizador de áudio interno.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
 #endif
    {
       "genesis_plus_gx_frameskip",
       "Pulo de quadro",
+      NULL,
       "Pula quadros para evitar subexecução do buffer de áudio (estalos). Melhora o desempenho em detrimento da suavidade visual. 'Auto' pula os quadros quando aconselhado pela interface. 'Manual' utiliza a configuração 'Limite de pulo de quadro (%).",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_frameskip_threshold",
       "Limite de pulo de quadro (%)",
+      NULL,
       "Quando 'Pulo de quadro' é definido como 'Manual', especifica o limite de ocupação do buffer de áudio (porcentagem) abaixo do qual os quadros serão ignorados. Valores mais altos reduzem o risco de estalos, fazendo com que os quadros sejam suprimidos com mais frequência.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "33"
+      NULL
    },
    {
       "genesis_plus_gx_blargg_ntsc_filter",
       "Filtro Blargg NTSC",
+      NULL,
       "Aplica um filtro de vídeo para imitar vários sinais de TV NTSC.",
+      NULL,
+      NULL,
       {
          { "disabled",   NULL },
          { "monochrome", "Monocromático" },
@@ -273,21 +348,27 @@ struct retro_core_option_definition option_defs_pt_br[] = {
          { "rgb",        "RGB" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_lcd_filter",
       "Filtro fantasma LCD",
+      NULL,
       "Aplica um filtro de imagem fantasma para imitar as características de exibição dos painéis de LCD do Game Gear e do 'Genesis Nomad'.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_overscan",
       "Bordas",
+      NULL,
       "Ative esta opção para exibir as regiões de overscan na parte superior/inferior e/ou esquerda/direita da tela. Normalmente, seriam ocultas pelo painel ao redor da borda de uma televisão de definição padrão.",
+      NULL,
+      NULL,
       {
          { "disabled",   NULL },
          { "top/bottom", "Superior/inferior" },
@@ -295,280 +376,370 @@ struct retro_core_option_definition option_defs_pt_br[] = {
          { "full",       "Completa" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_gg_extra",
       "Tela estendida do Game Gear",
+      NULL,
       "Força os títulos do Game Gear a serem executados no modo 'SMS', com uma resolução aumentada de 256x192. Pode mostrar conteúdo adicional, mas geralmente exibe uma borda de dados corrompidos/indesejados de imagem.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_left_border",
       "Ocultar borda esquerda do Master System",
+      NULL,
       "Corta 8 pixels do lado esquerdo e direito da tela ao executar os jogos do Master System, ocultando assim a borda vista no lado esquerdo da tela",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_aspect_ratio",
       "Proporção de aspecto fornecida pelo núcleo",
+      NULL,
       "Escolhe a proporção preferida do conteúdo. Isso se aplicará somente quando a proporção do RetroArch estiver configurada como 'Core provided' nas configurações de vídeo.",
+      NULL,
+      NULL,
       {
-         { "auto",     NULL },
-         { "NTSC PAR", NULL },
-         { "PAL PAR",  NULL },
+         { NULL, NULL },
       },
-      "auto"
+      NULL
    },
    {
       "genesis_plus_gx_render",
       "Saída entrelaçada modo 2",
+      NULL,
       "O Modo entrelaçado 2 permite que o Mega Drive produza uma imagem de 320x448 de altura dupla (alta resolução) desenhando linhas de varredura alternativas em cada quadro (isso é usado pelos modos multijogador do 'Sonic the Hedgehog 2' e 'Combat Cars'). O 'Campo duplo' imita o hardware original, produzindo uma imagem nítida com artefatos trêmulos/entrelaçados. O 'Campo único' é um filtro de desentrelaçamento, que estabiliza a imagem, mas causa desfoque suave.",
+      NULL,
+      NULL,
       {
          { "single field", "Campo único" },
          { "double field", "Campo duplo" },
          { NULL, NULL },
       },
-      "single field"
+      NULL
    },
    {
       "genesis_plus_gx_gun_cursor",
       "Mostrar mira da pistola",
+      NULL,
       "Exibe a mira da pistola de luz ao usar os tipos de dispositivo de entrada 'MD Menacer', 'MD Justifiers' e 'MS Light Phaser'.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_gun_input",
       "Saída da Pistola de luz",
+      NULL,
       "Usa uma entrada 'Pistola de luz' ou 'Toque na tela' controlada por mouse.",
+      NULL,
+      NULL,
       {
          { "lightgun",    "Pistola de luz" },
          { "touchscreen", "Toque na tela" },
          { NULL, NULL },
       },
-      "lightgun"
+      NULL
    },
    {
       "genesis_plus_gx_invert_mouse",
       "Inverter eixo Y do mouse",
+      NULL,
       "Inverte o eixo Y do tipo de dispositivo de entrada 'MD Mouse'.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
 #ifdef HAVE_OVERCLOCK
    {
       "genesis_plus_gx_overclock",
       "Velocidade da CPU",
+      NULL,
       "Faz um overclock da CPU emulada. Pode reduzir a desaceleração, mas pode causar falhas.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100%"
+      NULL
    },
 #endif
    {
       "genesis_plus_gx_no_sprite_limit",
       "Remover limite de sprite por linha",
+      NULL,
       "Remove o limite de sprite por varredura do hardware, 8 (Master System) ou 20 (Mega Drive). Isso reduz a tremulação (flickering), mas pode causar falhas visuais, pois alguns jogos exploram o limite de hardware para gerar efeitos especiais.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
 #ifdef USE_PER_SOUND_CHANNELS_CONFIG
    {
       "genesis_plus_gx_show_advanced_audio_settings",
       "Mostrar configurações avançadas de volume de áudio (reabrir menu)",
+      NULL,
       "Ativa a configuração dos parâmetros do canal de áudio de baixo nível. NOTA: O Menu rápido deve ser alternado para que esta configuração tenha efeito.",
+      NULL,
+      NULL,
       {
          { NULL, NULL},
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_psg_channel_0_volume",
       "% do volume do tom do PSG do canal 0",
+      NULL,
       "Reduz o volume do tom PSG do canal 0.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_psg_channel_1_volume",
       "% do volume do tom do PSG do canal 1",
+      NULL,
       "Reduz o volume do tom PSG do canal 1.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_psg_channel_2_volume",
       "% do volume do tom do PSG do canal 2",
+      NULL,
       "Reduz o volume do tom PSG do canal 2.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_psg_channel_3_volume",
       "% do volume de ruído do PSG do canal 3",
+      NULL,
       "Reduz o volume do ruído do PSG do canal 3.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_md_channel_0_volume",
       "% do volume do FM do Mega Drive do canal 0",
+      NULL,
       "Reduz o volume do FM do Mega Drive do canal 0. Só funciona com o emulador de FM do MAME.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_md_channel_1_volume",
       "% do volume do FM do Mega Drive do canal 1",
+      NULL,
       "Reduz o volume do FM do Mega Drive do canal 1. Só funciona com o emulador de FM do MAME.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_md_channel_2_volume",
       "% do volume do FM do Mega Drive do canal 2",
+      NULL,
       "Reduz o volume do FM do Mega Drive do canal 2. Só funciona com o emulador de FM do MAME.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_md_channel_3_volume",
       "% do volume do FM do Mega Drive do canal 3",
+      NULL,
       "Reduz o volume do FM do Mega Drive do canal 3. Só funciona com o emulador de FM do MAME.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_md_channel_4_volume",
       "% do volume do FM do Mega Drive do canal 4",
+      NULL,
       "Reduz o volume do FM do Mega Drive do canal 4. Só funciona com o emulador de FM do MAME.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_md_channel_5_volume",
       "% do volume do FM do Mega Drive do canal 5",
+      NULL,
       "Reduz o volume do FM do Mega Drive do canal 5. Só funciona com o emulador de FM do MAME.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_sms_fm_channel_0_volume",
       "% do volume do som FM do Master System (YM2413) do canal 0",
+      NULL,
       "Reduz o volume do som FM do Master System do canal 0.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_sms_fm_channel_1_volume",
       "% do volume do som FM do Master System (YM2413) do canal 1",
+      NULL,
       "Reduz o volume do som FM do Master System do canal 1.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_sms_fm_channel_2_volume",
       "% do volume do som FM do Master System (YM2413) do canal 2",
+      NULL,
       "Reduz o volume do som FM do Master System do canal 2.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_sms_fm_channel_3_volume",
       "% do volume do som FM do Master System (YM2413) do canal 3",
+      NULL,
       "Reduz o volume do som FM do Master System do canal 3.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_sms_fm_channel_4_volume",
       "% do volume do som FM do Master System (YM2413) do canal 4",
+      NULL,
       "Reduz o volume do som FM do Master System do canal 4.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_sms_fm_channel_5_volume",
       "% do volume do som FM do Master System (YM2413) do canal 5",
+      NULL,
       "Reduz o volume do som FM do Master System do canal 5.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_sms_fm_channel_6_volume",
       "% do volume do som FM do Master System (YM2413) do canal 6",
+      NULL,
       "Reduz o volume do som FM do Master System do canal 6.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_sms_fm_channel_7_volume",
       "% do volume do som FM do Master System (YM2413) do canal 7",
+      NULL,
       "Reduz o volume do som FM do Master System do canal 7.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_sms_fm_channel_8_volume",
       "% do volume do som FM do Master System (YM2413) do canal 8",
+      NULL,
       "Reduz o volume do som FM do Master System do canal 8.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
 #endif
-   { NULL, NULL, NULL, {{0}}, NULL },
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+
+struct retro_core_options_v2 options_pt_br = {
+   option_cats_pt_br,
+   option_defs_pt_br
 };
 
 /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
@@ -593,500 +764,410 @@ struct retro_core_option_definition option_defs_pt_br[] = {
 
 /* RETRO_LANGUAGE_TURKISH */
 
-	struct retro_core_option_definition option_defs_tr[] = {
+struct retro_core_option_v2_category option_cats_tr[] = {
+   {
+      "system",
+      NULL,
+      NULL
+   },
+   {
+      "video",
+      NULL,
+      NULL
+   },
+   {
+      "audio",
+      NULL,
+      NULL
+   },
+   {
+      "input",
+      NULL,
+      NULL
+   },
+   {
+      "hacks",
+      NULL,
+      NULL
+   },
+   {
+      "channel_volume",
+      NULL,
+      NULL
+   },
+   { NULL, NULL, NULL },
+};
+
+struct retro_core_option_v2_definition option_defs_tr[] = {
    {
       "genesis_plus_gx_system_hw",
       "Sistem Donanımı",
+      NULL,
       "Yüklenen içeriği belirli bir öykünmüş konsolla çalıştırır. 'Otomatik' mevcut oyun için en uygun sistemi seçecektir.",
+      NULL,
+      NULL,
       {
-         { "auto",                 "Otomatik"               },
-         { "sg-1000",              "SG-1000"            },
-         { "sg-1000 II",           "SG-1000 II"         },
-         { "mark-III",             "Mark III"           },
-         { "master system",        "Master System"      },
-         { "master system II",     "Master System II"   },
-         { "game gear",            "Game Gear"          },
-         { "mega drive / genesis", "Mega Drive/Genesis" },
          { NULL, NULL },
       },
-      "auto"
+      NULL
    },
    {
       "genesis_plus_gx_region_detect",
       "Sistem Bölgesi",
+      NULL,
       "Sistemin hangi bölgeden olduğunu belirtin. Game Gear dışındaki konsollar için 'PAL' 50hz, 'NTSC' 60hz'dir. Yanlış bölge seçiliyse, oyunlar normalden daha hızlı veya daha yavaş çalışabilir.",
+      NULL,
+      NULL,
       {
-         { "auto",    "Otomatik"   },
-         { "ntsc-u",  "NTSC-U" },
-         { "pal",     "PAL"    },
-         { "ntsc-j",  "NTSC-J" },
+         { "auto",    "Otomatik" },
+         { "ntsc-u",  "NTSC-U"   },
+         { "pal",     "PAL"      },
+         { "ntsc-j",  "NTSC-J"   },
          { NULL, NULL },
       },
-      "auto"
+      NULL
    },
    {
       "genesis_plus_gx_force_dtack",
       "Sistem Kilidi",
+      NULL,
       "Geçersiz adres erişimi gerçekleştirirken gerçek donanımda meydana gelen sistem kilitlemelerine öykünün. Bu, yalnızca doğru işlem için yasadışı davranışa dayanan belirli demolar ve homebrew oynatılırken devre dışı bırakılmalıdır.",
+      NULL,
+      NULL,
       {
-         { "enabled",  "Etkinleştir" },
-         { "disabled",  "Devre Dışı" },
          { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "genesis_plus_gx_bios",
       "Sistem Önyükleme ROM'u",
+      NULL,
       "RetroArch'ın sistem dizininde varsa, öykünülmüş donanım için resmi BIOS/önyükleyici kullanın. Konsola özgü başlangıç sırası/animasyonu görüntüler, ardından yüklü içeriği çalıştırır.",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Devre Dışı" },
-         { "enabled",  "Etkinleştir" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_bram",
       "CD Sistemi BRAM'i",
+      NULL,
       "Sega CD içeriği çalıştırılırken, belirli bir bölgedeki tüm oyunlar arasında (BIOS başına) tek bir kayıt dosyasının paylaşılmasını mı yoksa her oyun için ayrı bir kayıt dosyası oluşturup oluşturmamayı (Oyun Başına) belirtir. Sega CD'sinin sınırlı bir dahili depolama alanına sahip olduğunu ve yalnızca bir avuç başlık için yeterli olduğunu unutmayın. Boşluktan kaçınmak için 'Oyun Başına' ayarı önerilir.",
+      NULL,
+      NULL,
       {
          { "per bios", "BIOS Başına" },
          { "per game", "Oyun Başına" },
          { NULL, NULL },
       },
-      "per bios"
+      NULL
    },
    {
       "genesis_plus_gx_addr_error",
       "68K Adres Hatası",
+      NULL,
       "Genesis CPU (Motorola 68000), hizalanmamış hafıza erişimi gerçekleştirmeye çalışırken bir Adres Hatası (kilitlenme) üretir. '68K Adres Hatası' özelliğini etkinleştirmek bu davranışı simüle eder. ROM hacklerini oynarken sadece devre dışı bırakılmalıdır, çünkü bunlar daha az doğru emülatörler kullanılarak geliştirilir ve doğru işlem için geçersiz RAM erişimine güvenebilir.",
+      NULL,
+      NULL,
       {
-         { "enabled",  "Etkinleştir" },
-         { "disabled",  "Devre Dışı" },
          { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "genesis_plus_gx_lock_on",
       "Kartuş Kilitleme",
+      NULL,
       "Kilitleme Teknolojisi, eski bir oyunun genişletilmiş veya değiştirilmiş bir oyun için özel bir kartuşun geçiş portuna bağlanmasına izin veren bir Genesis özelliğidir. Bu seçenek, hangi tür 'özel kilitleme' kartuşunun taklit edileceğini belirler. RetroArch'ın sistem dizininde ilgili bir bios dosyası bulunmalıdır.",
+      NULL,
+      NULL,
       {
-         { "disabled",            "Devre Dışı" },
-         { "game genie",          "Game Genie" },
-         { "action replay (pro)", "Action Replay (Pro)" },
-         { "sonic & knuckles",    "Sonic & Knuckles" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_ym2413",
       "Master System FM (YM2413)",
+      NULL,
       "Gelişmiş ses çıkışı için bazı Sega Mark III / Master System oyunları tarafından kullanılan FM Ses Ünitesinin emülasyonunu etkinleştirin.",
+      NULL,
+      NULL,
       {
          { "auto",     "Otomatik" },
-         { "disabled",  "Devre Dışı" },
-         { "enabled",  "Etkinleştir" },
+         { "disabled", NULL       },
+         { "enabled",  NULL       },
          { NULL, NULL },
       },
-      "auto"
+      NULL
    },
    {
       "genesis_plus_gx_ym2612",
       "Mega Drive / Genesis FM",
+      NULL,
 #ifdef HAVE_YM3438_CORE
       "Mega Drive / Genesis'in FM sentezleyicisini (ana ses üreteci) taklit etmek için kullanılan yöntemi seçin. 'MAME' seçenekleri hızlı ve çoğu sistemde tam hızda çalışıyor. 'Nuke' seçenekleri döngüde doğrudur, çok kaliteli ve önemli CPU gereksinimlerine sahiptir. 'YM2612' yongası, orijinal Model 1 Genesis tarafından kullanılır. 'YM3438' daha sonra Genesis revizyonlarında kullanılır.",
 #else
       "Mega Drive / Genesis'in FM sentezleyicisini (ana ses üreteci) taklit etmek için kullanılan yöntemi seçin. 'YM2612' yongası, orijinal Model 1 Genesis tarafından kullanılır. 'YM3438' daha sonra Genesis revizyonlarında kullanılır.",
 #endif
+      NULL,
+      NULL,
       {
-         { "mame (ym2612)",          "MAME (YM2612)" },
-         { "mame (asic ym3438)",     "MAME (ASIC YM3438)" },
-         { "mame (enhanced ym3438)", "MAME (Enhanced YM3438)" },
-#ifdef HAVE_YM3438_CORE
-         { "nuked (ym2612)",         "Nuked (YM2612)" },
-         { "nuked (ym3438)",         "Nuked (YM3438)" },
-#endif
          { NULL, NULL },
       },
-      "mame (ym2612)"
+      NULL
    },
    {
       "genesis_plus_gx_sound_output",
       "Ses Çıkışı",
+      NULL,
       "Stereo veya mono ses üretimini seçin.",
+      NULL,
+      NULL,
       {
-         { "stereo", "Stereo" },
-         { "mono",   "Mono" },
          { NULL, NULL },
       },
-      "stereo"
+      NULL
    },
    {
       "genesis_plus_gx_psg_preamp",
       "PSG Preamp Level",
+      NULL,
       "Master System, Game Gear ve Genesis'de bulunan öykünmüş SN76496 4 kanallı Programlanabilir Ses Üretecinin ses ön yükselticisi seviyesini ayarlayın.",
+      NULL,
+      NULL,
       {
-         { "0",   NULL },
-         { "5",   NULL },
-         { "10",  NULL },
-         { "15",  NULL },
-         { "20",  NULL },
-         { "25",  NULL },
-         { "30",  NULL },
-         { "35",  NULL },
-         { "40",  NULL },
-         { "45",  NULL },
-         { "50",  NULL },
-         { "55",  NULL },
-         { "60",  NULL },
-         { "65",  NULL },
-         { "70",  NULL },
-         { "75",  NULL },
-         { "80",  NULL },
-         { "85",  NULL },
-         { "90",  NULL },
-         { "95",  NULL },
-         { "100", NULL },
-         { "105", NULL },
-         { "110", NULL },
-         { "115", NULL },
-         { "120", NULL },
-         { "125", NULL },
-         { "130", NULL },
-         { "135", NULL },
-         { "140", NULL },
-         { "145", NULL },
-         { "150", NULL },
-         { "155", NULL },
-         { "160", NULL },
-         { "165", NULL },
-         { "170", NULL },
-         { "175", NULL },
-         { "180", NULL },
-         { "185", NULL },
-         { "190", NULL },
-         { "195", NULL },
-         { "200", NULL },
          { NULL, NULL },
       },
-      "150"
+      NULL
    },
    {
       "genesis_plus_gx_fm_preamp",
       "FM Preamp Level",
+      NULL,
       "Öykünülmüş Sega Mark III/Master System FM Ses Ünitesinin ses ön yükselticisi seviyesini ayarlayın.",
+      NULL,
+      NULL,
       {
-         { "0",   NULL },
-         { "5",   NULL },
-         { "10",  NULL },
-         { "15",  NULL },
-         { "20",  NULL },
-         { "25",  NULL },
-         { "30",  NULL },
-         { "35",  NULL },
-         { "40",  NULL },
-         { "45",  NULL },
-         { "50",  NULL },
-         { "55",  NULL },
-         { "60",  NULL },
-         { "65",  NULL },
-         { "70",  NULL },
-         { "75",  NULL },
-         { "80",  NULL },
-         { "85",  NULL },
-         { "90",  NULL },
-         { "95",  NULL },
-         { "100", NULL },
-         { "105", NULL },
-         { "110", NULL },
-         { "115", NULL },
-         { "120", NULL },
-         { "125", NULL },
-         { "130", NULL },
-         { "135", NULL },
-         { "140", NULL },
-         { "145", NULL },
-         { "150", NULL },
-         { "155", NULL },
-         { "160", NULL },
-         { "165", NULL },
-         { "170", NULL },
-         { "175", NULL },
-         { "180", NULL },
-         { "185", NULL },
-         { "190", NULL },
-         { "195", NULL },
-         { "200", NULL },
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_audio_filter",
       "Ses Filtresi",
+      NULL,
       "Model 1 Genesis'in karakteristik sesini daha iyi simüle etmek için düşük geçişli bir ses filtresini etkinleştirin.",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Devre Dışı" },
-         { "low-pass", "Low-Pass" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_lowpass_range",
       "Low-Pass Filtresi %",
+      NULL,
       "Düşük ses geçiş filtresinin kesme frekansını belirtin. Daha yüksek bir değer, yüksek frekans spektrumunun daha geniş bir aralığı azaltıldığı için filtrenin algılanan gücünü arttırır.",
+      NULL,
+      NULL,
       {
-         { "5",  NULL },
-         { "10", NULL },
-         { "15", NULL },
-         { "20", NULL },
-         { "25", NULL },
-         { "30", NULL },
-         { "35", NULL },
-         { "40", NULL },
-         { "45", NULL },
-         { "50", NULL },
-         { "55", NULL },
-         { "60", NULL },
-         { "65", NULL },
-         { "70", NULL },
-         { "75", NULL },
-         { "80", NULL },
-         { "85", NULL },
-         { "90", NULL },
-         { "95", NULL },
          { NULL, NULL },
       },
-      "60"
+      NULL
    },
 #ifdef HAVE_EQ
    {
       "genesis_plus_gx_audio_eq_low",
       "EQ Low",
+      NULL,
       "Dahili ses ekolayzırın düşük aralık bandını ayarlayın.",
+      NULL,
+      NULL,
       {
-         { "0",   NULL },
-         { "5",   NULL },
-         { "10",  NULL },
-         { "15",  NULL },
-         { "20",  NULL },
-         { "25",  NULL },
-         { "30",  NULL },
-         { "35",  NULL },
-         { "40",  NULL },
-         { "45",  NULL },
-         { "50",  NULL },
-         { "55",  NULL },
-         { "60",  NULL },
-         { "65",  NULL },
-         { "70",  NULL },
-         { "75",  NULL },
-         { "80",  NULL },
-         { "85",  NULL },
-         { "90",  NULL },
-         { "95",  NULL },
-         { "100", NULL },
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_audio_eq_mid",
       "EQ Mid",
+      NULL,
       "Dahili ses ekolayzerinin orta aralık bandını ayarlayın.",
+      NULL,
+      NULL,
       {
-         { "0",   NULL },
-         { "5",   NULL },
-         { "10",  NULL },
-         { "15",  NULL },
-         { "20",  NULL },
-         { "25",  NULL },
-         { "30",  NULL },
-         { "35",  NULL },
-         { "40",  NULL },
-         { "45",  NULL },
-         { "50",  NULL },
-         { "55",  NULL },
-         { "60",  NULL },
-         { "65",  NULL },
-         { "70",  NULL },
-         { "75",  NULL },
-         { "80",  NULL },
-         { "85",  NULL },
-         { "90",  NULL },
-         { "95",  NULL },
-         { "100", NULL },
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
    {
       "genesis_plus_gx_audio_eq_high",
       "EQ High",
+      NULL,
       "Dahili ses ekolayzerinin yüksek aralık bandını ayarlayın.",
+      NULL,
+      NULL,
       {
-         { "0",   NULL },
-         { "5",   NULL },
-         { "10",  NULL },
-         { "15",  NULL },
-         { "20",  NULL },
-         { "25",  NULL },
-         { "30",  NULL },
-         { "35",  NULL },
-         { "40",  NULL },
-         { "45",  NULL },
-         { "50",  NULL },
-         { "55",  NULL },
-         { "60",  NULL },
-         { "65",  NULL },
-         { "70",  NULL },
-         { "75",  NULL },
-         { "80",  NULL },
-         { "85",  NULL },
-         { "90",  NULL },
-         { "95",  NULL },
-         { "100", NULL },
          { NULL, NULL },
       },
-      "100"
+      NULL
    },
 #endif
    {
       "genesis_plus_gx_blargg_ntsc_filter",
       "Blargg NTSC Filtresi",
+      NULL,
       "Çeşitli NTSC TV sinyallerini taklit etmek için bir video filtresi uygulayın.",
+      NULL,
+      NULL,
       {
-         { "disabled",   "Devre Dışı" },
-         { "monochrome", "Monochrome" },
-         { "composite",  "Composite" },
-         { "svideo",     "S-Video" },
-         { "rgb",        "RGB" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_lcd_filter",
       "LCD Gölgelenme Filtresi",
+      NULL,
       "Game Gear ve 'Genesis Nomad' LCD panellerinin ekran özelliklerini taklit etmek için bir görüntü “gölgelenme” filtresi uygulayın.",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Devre Dışı" },
-         { "enabled",  "Etkinleştir" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_overscan",
       "Çerçeveler",
+      NULL,
       "Aşırı tarama bölgelerini ekranın üstünde/altında ve/veya sol/sağında görüntülemek için bunu etkinleştirin. Bunlar normalde standart tanımlı bir televizyonun kenarındaki çerçeve tarafından gizlenir.",
+      NULL,
+      NULL,
       {
-         { "disabled",   "Devre Dışı" },
+         { "disabled",   NULL             },
          { "top/bottom", "Üstünde/Atında" },
-         { "left/right", "Sol/Sağ" },
-         { "full",       "Tam" },
+         { "left/right", "Sol/Sağ"        },
+         { "full",       "Tam"            },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_gg_extra",
       "Game Gear Genişletilmiş Ekran",
+      NULL,
       "Game Gear oyunlarını 256x192 çözünürlüğe sahip 'SMS' modunda çalıştırmaya zorlar. Ek içerik gösterebilir, ancak genellikle bozuk/istenmeyen resim verilerinin kenarlığını görüntüler.",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Devre Dışı" },
-         { "enabled",  "Etkinleştir" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_aspect_ratio",
       "Çekirdek Tarafından Sağlanan En Boy Oranı",
+      NULL,
       "Tercih edilen içerik en boy oranını seçin. Bu, yalnızca RetroArch’ın en boy oranı Video ayarlarında 'Çekirdek Tarafından Sağlanan' olarak ayarlandığında uygulanacaktır.",
+      NULL,
+      NULL,
       {
          { "auto",     "Otomatik" },
-         { "NTSC PAR", NULL },
-         { "PAL PAR",  NULL },
+         { "NTSC PAR", NULL       },
+         { "PAL PAR",  NULL       },
       },
-      "auto"
+      NULL
    },
    {
       "genesis_plus_gx_render",
       "Geçmeli Mod 2 Çıkışı",
+      NULL,
       "Geçmeli Mod 2, Genesis'e, her kareye alternatif tarama çizgileri çizerek (bu, 'Sonic the Hedgehog 2' ve 'Savaş Arabaları' çok oyunculu modları tarafından kullanılır) çift yükseklikte (yüksek çözünürlüklü) 320x448 görüntü vermesini sağlar. 'Çift Alan' orijinal donanımı taklit eder, titreyen/birbirine geçen eserler ile keskin bir görüntü oluşturur. 'Tek Alan', görüntüyü dengeleyen ancak hafif bulanıklığa neden olan, birbirinin yerine geçen bir filtredir.",
+      NULL,
+      NULL,
       {
-         { "single field", "Tek Alan" },
+         { "single field", "Tek Alan"  },
          { "double field", "Çift Alan" },
          { NULL, NULL },
       },
-      "single field"
+      NULL
    },
    {
       "genesis_plus_gx_gun_cursor",
       "Light Gun Göstergesini Göster",
+      NULL,
       "'MD Menacer', 'MD Justifiers' ve 'MS Light Phaser' giriş cihazı tiplerini kullanırken Light Gun göstergelerini gösterin.",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Devre Dışı" },
-         { "enabled",  "Etkinleştir" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "genesis_plus_gx_gun_input",
       "Light Gun Girdisi",
+      NULL,
       "Fare kontrollü 'Light Gun' veya 'Dokunmatik Ekran' girişi kullanın.",
+      NULL,
+      NULL,
       {
-         { "lightgun",    "Light Gun" },
+         { "lightgun",    "Light Gun"        },
          { "touchscreen", "Dokunmatik Ekran" },
          { NULL, NULL },
       },
-      "lightgun"
+      NULL
    },
    {
       "genesis_plus_gx_invert_mouse",
       "Fare Y Eksenini Ters Çevir",
+      NULL,
       "'MD Fare' giriş cihazı türünün Y eksenini ters çevirir.",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Devre Dışı" },
-         { "enabled",  "Etkinleştir" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
 #ifdef HAVE_OVERCLOCK
    {
       "genesis_plus_gx_overclock",
       "CPU Hızı",
+      NULL,
       "Öykünülmüş CPU hız aşırtması. Yavaşlamayı azaltabilir, ancak aksaklığa neden olabilir.",
+      NULL,
+      NULL,
       {
-         { "100%", NULL },
-         { "125%", NULL },
-         { "150%", NULL },
-         { "175%", NULL },
-         { "200%", NULL },
          { NULL, NULL },
       },
-      "100%"
+      NULL
    },
 #endif
    {
       "genesis_plus_gx_no_sprite_limit",
       "Satır Başına Sprite Limitini Kaldır",
+      NULL,
       "8 (Ana Sistem) veya 20 (Genesis) tarama başına sprite donanım sınırını kaldırır. Bu, titremeyi azaltır ancak bazı oyunlar özel efektler oluşturmak için donanım sınırını kullandığı için görsel hatalara neden olabilir.",
+      NULL,
+      NULL,
       {
-         { "disabled",  "Devre Dışı" },
-         { "enabled",  "Etkinleştir" },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
-   { NULL, NULL, NULL, {{0}}, NULL },
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+
+struct retro_core_options_v2 options_tr = {
+   option_cats_tr,
+   option_defs_tr
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR adds core option v2 support. On frontends with core option category support, options will be displayed in submenus for greater clarity:

![Screenshot_2021-08-11_15-49-18](https://user-images.githubusercontent.com/38211560/129053451-5a90d9e1-115b-4d7b-9aed-665f579a281c.png)

![Screenshot_2021-08-11_15-49-33](https://user-images.githubusercontent.com/38211560/129053482-bbb4fc8e-facf-4310-b9c2-8fee57559456.png)

![Screenshot_2021-08-11_15-50-02](https://user-images.githubusercontent.com/38211560/129053512-9eeed2bb-b30c-438c-83cf-421754d6414a.png)

![Screenshot_2021-08-11_15-50-29](https://user-images.githubusercontent.com/38211560/129053529-40d4b6ea-da02-4f80-af77-ff0034b74e34.png)

![Screenshot_2021-08-11_15-50-40](https://user-images.githubusercontent.com/38211560/129053548-3ebac667-c4bf-4ecb-947e-4704c079a3f3.png)

![Screenshot_2021-08-11_15-51-00](https://user-images.githubusercontent.com/38211560/129053561-9ef0d2f4-5fae-4b90-ac36-a7c43eaaae7a.png)

![Screenshot_2021-08-11_15-51-13](https://user-images.githubusercontent.com/38211560/129053576-131a4b23-558b-4130-acad-041f23361962.png)

This PR also generally reorders the core options, since they were in somewhat of a muddle...