### PR TITLE
Prevent the loading of content that exceeds the maximum size limit

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -7,6 +7,7 @@ HOOK_CPU = 0
 HAVE_CDROM = 0
 USE_PER_SOUND_CHANNELS_CONFIG = 1
 LOW_MEMORY = 0
+MAX_ROM_SIZE = 10485760
 
 CORE_DIR := .
 
@@ -87,7 +88,8 @@ ifneq (,$(findstring unix,$(platform)))
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined
    ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN
-   PLATFORM_DEFINES := -DHAVE_ZLIB -DMAXROMSIZE=33554432
+   PLATFORM_DEFINES := -DHAVE_ZLIB
+   MAX_ROM_SIZE = 33554432
 
    ifneq ($(findstring Linux,$(shell uname -s)),)
      HAVE_CDROM = 1
@@ -213,7 +215,8 @@ ifeq ($(arch),ppc)
 else
    ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN
 endif
-   PLATFORM_DEFINES := -DHAVE_ZLIB -DMAXROMSIZE=33554432
+   PLATFORM_DEFINES := -DHAVE_ZLIB
+   MAX_ROM_SIZE = 33554432
 
    OSXVER = `sw_vers -productVersion | cut -d. -f 2`
    OSX_LT_MAVERICKS = `(( $(OSXVER) <= 9)) && echo "YES"`
@@ -241,7 +244,8 @@ else ifneq (,$(findstring ios,$(platform)))
    fpic := -fPIC
    SHARED := -dynamiclib
    ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN
-   PLATFORM_DEFINES := -DHAVE_ZLIB -DMAXROMSIZE=16777216
+   PLATFORM_DEFINES := -DHAVE_ZLIB
+   MAX_ROM_SIZE = 16777216
    MINVERSION :=
 
    ifeq ($(IOSSDK),)
@@ -715,9 +719,9 @@ else
    CXX ?= g++
    SHARED := -shared -static-libgcc -static-libstdc++ -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined
    ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN
-   PLATFORM_DEFINES := -DHAVE_ZLIB -DMAXROMSIZE=33554432 -DENABLE_SUB_68K_ADDRESS_ERROR_EXCEPTIONS
+   PLATFORM_DEFINES := -DHAVE_ZLIB -DENABLE_SUB_68K_ADDRESS_ERROR_EXCEPTIONS
    HAVE_CDROM = 1
-
+   MAX_ROM_SIZE = 33554432
 endif
 
 ifeq ($(SHARED_LIBVORBIS), 1)
@@ -800,7 +804,8 @@ LIBRETRO_CFLAGS += $(BPP_DEFINES) \
 		-DM68K_OVERCLOCK_SHIFT=20 \
 		-DZ80_OVERCLOCK_SHIFT=20 \
 		-DHAVE_YM3438_CORE \
-		-DHAVE_OPLL_CORE
+		-DHAVE_OPLL_CORE \
+		-DMAXROMSIZE=$(MAX_ROM_SIZE)
 
 ifneq (,$(findstring msvc,$(platform)))
    LIBRETRO_CFLAGS += -DINLINE="static _inline"


### PR DESCRIPTION
At present, when loading content via a frontend memory buffer the core will accept content that is larger than the maximum permitted size while silently truncating the excess data. This means that large games (e.g. Demons of Asteborg) will appear to load correctly on memory-limited platforms, but since the ROM data is incomplete, chaos will ensue while the game is actually running.

This PR ensures that content will always fail to load if it exceeds the maximum allowed size. A notification will also be presented to the user:

![Screenshot_2021-10-15_16-09-17](https://user-images.githubusercontent.com/38211560/137516450-272de27b-82ee-478a-abba-a3614f773f4b.png)

The PR additionally:

- Fixes a memory leak when content fails to load
- Modifies the way that `MAXROMSIZE` is defined in `Makefile.libretro` so that it is easier to set a larger maximum by default and reduce the value for specific platforms, if it is decided that we want to do this