### PR TITLE
Fix translate workflow + minor change to intl file reconstruction script

### DIFF
--- a/.github/workflows/crowdin_translate.yml
+++ b/.github/workflows/crowdin_translate.yml
@@ -4,7 +4,7 @@ name: Crowdin Translation Integration
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # every day at midnight
+    - cron: '10 15 * * *'  # 3:10 PM, UTC
 
 jobs:
   create_intl_file:
@@ -35,7 +35,7 @@ jobs:
         run: |
           git config --local user.email "github-actions@github.com"
           git config --local user.name "github-actions[bot]"
-          git add intl/translation_workflow.py "libretro/libretro_core_options_intl.h"
+          git add intl/download_workflow.py "libretro/libretro_core_options_intl.h"
           git commit -m "Fetch translations & Recreate libretro_core_options_intl.h"
 
       - name: GitHub Push

--- a/intl/core_option_translation.py
+++ b/intl/core_option_translation.py
@@ -519,15 +519,18 @@ def create_intl_file(localisation_file_path: str, intl_dir_path: str, text: str,
     overwrite = False
 
     # iterate through localisation files
-    for file in os.scandir(intl_dir_path):  # intl/<core_name>/_*
-        if file.is_file() \
-                and file.name.startswith('_') \
-                and file.name.endswith('.h') \
-                and not file.name.startswith('_us'):
-            translation_path = file.path  # <core_name>_<lang>.h
+    files = {}
+    for file in os.scandir(intl_dir_path):
+        files[file.name] = {'is_file': file.is_file(), 'path': file.path}
+    for file in sorted(files):  # intl/<core_name>/_*
+        if files[file]['is_file'] \
+                and file.startswith('_') \
+                and file.endswith('.h') \
+                and not file.startswith('_us'):
+            translation_path = files[file]['path']  # <core_name>_<lang>.h
             # all structs: group(0) full struct, group(1) beginning, group(2) content
             struct_groups = cor.p_struct.finditer(text)
-            lang_low = os.path.splitext(file.name)[0].lower()
+            lang_low = os.path.splitext(file)[0].lower()
             lang_up = lang_low.upper()
             out_txt = out_txt + f'/* RETRO_LANGUAGE{lang_up} */\n\n'  # /* RETRO_LANGUAGE_NM */
 


### PR DESCRIPTION
I forgot to include a file rename in the workflow, which led to it failing.

Also, I decided to sort the languages within `libretro_core_options_intl.h`, to hopefully reduce the number of (pointless) commits in the future.