### PR TITLE
Update Makefile.libretro

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -485,7 +485,6 @@ else ifeq ($(platform), miyoo)
    CFLAGS += -ffast-math -march=armv5te -mtune=arm926ej-s -fomit-frame-pointer
    ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN -DALIGN_LONG
    USE_PER_SOUND_CHANNELS_CONFIG = 0
-   MAX_ROM_SIZE = 16777216
 
 # Windows MSVC 2003 Xbox 1
 else ifeq ($(platform), xbox1_msvc2003)


### PR DESCRIPTION
Set MAX ROM SIZE =16777216 on Mips32 devices (GCW-Zero,etc) to run Demons of Asteborg