### PR TITLE
Fix visibility of 'hidable' core options when option categories are supported

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2561,6 +2561,7 @@ unsigned retro_api_version(void) { return RETRO_API_VERSION; }
 
 void retro_set_environment(retro_environment_t cb)
 {
+   bool option_categories = false;
    struct retro_vfs_interface_info vfs_iface_info;
 
    static const struct retro_controller_description port_1[] = {
@@ -2732,9 +2733,15 @@ void retro_set_environment(retro_environment_t cb)
 
    environ_cb = cb;
 
-   libretro_supports_option_categories = false;
-   libretro_set_core_options(environ_cb,
-         &libretro_supports_option_categories);
+   /* An annoyance: retro_set_environment() can be called
+    * multiple times, and depending upon the current frontend
+    * state various environment callbacks may be disabled.
+    * This means the reported 'categories_supported' status
+    * may change on subsequent iterations. We therefore have
+    * to record whether 'categories_supported' is true on any
+    * iteration, and latch the result */
+   libretro_set_core_options(environ_cb, &option_categories);
+   libretro_supports_option_categories |= option_categories;
 
    /* If frontend supports core option categories,
     * genesis_plus_gx_show_advanced_audio_settings


### PR DESCRIPTION
This trivial PR fixes a bug that causes 'visibility toggle' options to be mishandled when the frontend supports core option categories.