### PR TITLE
Sega/Mega CD Backup Ram Cart improvements

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1327,7 +1327,7 @@ static void check_variables(bool first_run)
   bool update_frameskip     = false;
   struct retro_variable var = {0};
 
-  var.key = "genesis_plus_gx_bram";
+  var.key = "genesis_plus_gx_system_bram";
   environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var);
   {
    if (!var.value || !strcmp(var.value, "per bios"))
@@ -1344,6 +1344,22 @@ static void check_variables(bool first_run)
      strlcpy(CD_BRAM_EU, newpath, sizeof(CD_BRAM_EU));
      strlcpy(CD_BRAM_US, newpath, sizeof(CD_BRAM_US));
      strlcpy(CD_BRAM_JP, newpath, sizeof(CD_BRAM_JP));
+   }
+  }
+
+  var.key = "genesis_plus_gx_cart_bram";
+  environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var);
+  {
+   if (!var.value || !strcmp(var.value, "per cart"))
+   {
+     fill_pathname_join(CART_BRAM, save_dir, "cart.brm", sizeof(CART_BRAM));
+   }
+   else
+   {
+     char newpath[4096];
+     fill_pathname_join(newpath, save_dir, g_rom_name, sizeof(newpath));
+     strlcat(newpath, "_cart.brm", sizeof(newpath));
+     strlcpy(CART_BRAM, newpath, sizeof(CART_BRAM));
    }
   }
 
@@ -3275,8 +3291,7 @@ bool retro_load_game(const struct retro_game_info *info)
    fill_pathname_join(CD_BIOS_EU, dir, "bios_CD_E.bin", sizeof(CD_BIOS_EU));
    fill_pathname_join(CD_BIOS_US, dir, "bios_CD_U.bin", sizeof(CD_BIOS_US));
    fill_pathname_join(CD_BIOS_JP, dir, "bios_CD_J.bin", sizeof(CD_BIOS_JP));
-   fill_pathname_join(CART_BRAM,  dir, "cart.brm",      sizeof(CART_BRAM));
-
+ 
    check_variables(true);
 
    if (log_cb)

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -146,7 +146,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
-      "genesis_plus_gx_bram",
+      "genesis_plus_gx_system_bram",
       "CD System BRAM",
       NULL,
       "When running Sega CD/Mega-CD content, specifies whether to share a single save file between all games from a specific region (Per-BIOS) or to create a separate save file for each game (Per-Game). Note that the Sega CD/Mega-CD has limited internal storage, sufficient only for a handful of titles. To avoid running out of space, the 'Per-Game' setting is recommended.",
@@ -158,6 +158,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "per bios"
+   },
+   {
+      "genesis_plus_gx_cart_bram",
+      "CD Backup Cart BRAM",
+      NULL,
+      "When running Sega CD/Mega-CD content, specifies whether to share a single backup ram cart for all games (Per-Cart) or to create a separate backup ram cart for each game (Per-Game).",
+      NULL,
+      "system",
+      {
+         { "per cart", "Per-Cart" },
+         { "per game", "Per-Game" },
+         { NULL, NULL },
+      },
+      "per cart"
    },
    {
       "genesis_plus_gx_add_on",


### PR DESCRIPTION
Add an option for the backup ram cart to be configurable per-cart or per-game.

Also, changed backup ram cart save location from system dir to save dir.

Closes #315