### PR TITLE
Sega/Mega CD Fix disabling backup ram cart

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1357,7 +1357,7 @@ static void check_variables(bool first_run)
     environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var);
     {
       if (var.value && !strcmp(var.value, "disabled"))
-        cart_size = 0;
+        cart_size = 0xff;
       else if (var.value && !strcmp(var.value, "128k"))
         cart_size = 1;
       else if (var.value && !strcmp(var.value, "256k"))


### PR DESCRIPTION
Fixes disabling backup ram cart not actually disabling.

Thanks to ekeeke for pointing it out in #327.
