### PR TITLE
Make EQ core options visible again

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -198,8 +198,8 @@ static bool libretro_supports_bitmasks          = false;
 
 #define SOUND_FREQUENCY 44100
 
-/* Hide the EQ settings for now */
-/*#define HAVE_EQ*/
+/*EQ settings*/
+#define HAVE_EQ
 
 /* Frameskipping Support */
 
@@ -1756,7 +1756,7 @@ static void check_variables(bool first_run)
     if (var.value && !strcmp(var.value, "low-pass"))
       config.filter = 1;
 
-#if HAVE_EQ 
+#ifdef HAVE_EQ 
     else if (var.value && !strcmp(var.value, "EQ"))
       config.filter = 2;
 #endif
@@ -1771,7 +1771,7 @@ static void check_variables(bool first_run)
     config.lp_range = (!var.value) ? 0x9999 : ((atoi(var.value) * 65536) / 100);
   }
 
-#if HAVE_EQ
+#ifdef HAVE_EQ
   var.key = "genesis_plus_gx_audio_eq_low";
   environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var);
   {

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -42,6 +42,7 @@ extern "C" {
 
 #if defined(M68K_OVERCLOCK_SHIFT) || defined(Z80_OVERCLOCK_SHIFT)
 #define HAVE_OVERCLOCK
+#define HAVE_EQ
 #endif
 
 /*
@@ -451,7 +452,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       {
          { "disabled", NULL },
          { "low-pass", "Low-Pass" },
-#if HAVE_EQ
+#ifdef HAVE_EQ
          { "EQ",       NULL },
 #endif
          { NULL, NULL },


### PR DESCRIPTION
Apparently the equalizer options were hidden on Sep 13, 2017 because of glitches.

* https://github.com/ekeeke/Genesis-Plus-GX/pull/169/commits/7f3d999735ed13ac2eee1f5fb42ada5599b4ba18#diff-0033c4d206c0f5ecb21459b1c42f39055aacfc7468b9729527c5dd94489c58aaR155

And then there was an update on Sep 19, 2017 that fixed the equalizer glitches.

* https://github.com/ekeeke/Genesis-Plus-GX/issues/71#issuecomment-330539222

But the equalizer options were never un-hidden.

My PR makes the equalizer options visible again.

I manually built the core on Windows 11 and tested the equalizer options on several games. The options worked fine and there was no crashes.