### PR TITLE
Deregister disk control callback when not running MCD

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -3672,6 +3672,8 @@ bool retro_load_game(const struct retro_game_info *info)
 
    if (system_hw == SYSTEM_MCD)
       bram_load();
+   else
+      environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, NULL);
 
    update_viewport();
 


### PR DESCRIPTION
Since it seems to be ok according to the docs, let's get rid of it when it is not needed.

> * May be \c NULL, in which case the existing disk callback is deregistered.

Closes #250