### PR TITLE
more robust ov_callbacks (fixes OGG Vorbis playback in Libretro), disable multiple OGG at once on GC/Wii/Wii U libretro

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -390,7 +390,7 @@ else ifneq (,$(filter $(platform), ngc wii wiiu))
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
 	ENDIANNESS_DEFINES := -DBYTE_ORDER=BIG_ENDIAN -DCPU_IS_BIG_ENDIAN=1 -DWORDS_BIGENDIAN=1
-   PLATFORM_DEFINES := -DGEKKO -mcpu=750 -meabi -mhard-float -DALT_RENDER
+   PLATFORM_DEFINES := -DGEKKO -mcpu=750 -meabi -mhard-float -DALT_RENDER -DDISABLE_MANY_OGG_OPEN_FILES
    PLATFORM_DEFINES += -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
    STATIC_LINKING = 1
    USE_PER_SOUND_CHANNELS_CONFIG = 0

--- a/core/cd_hw/cdd.c
+++ b/core/cd_hw/cdd.c
@@ -157,17 +157,15 @@ static const char extensions[SUPPORTED_EXT][16] =
 
 #if defined(USE_LIBTREMOR) || defined(USE_LIBVORBIS)
 
-static int seek64_wrap(void *f,ogg_int64_t off,int whence){
-  return cdStreamSeek(f,off,whence);
-}
-
-static ov_callbacks cb =
-{ 
-  (size_t (*)(void *, size_t, size_t, void *))  cdStreamRead,
-  (int (*)(void *, ogg_int64_t, int))           seek64_wrap,
-  (int (*)(void *))                             cdStreamClose,
-  (long (*)(void *))                            cdStreamTell
-};
+static int ov_seek64_wrap(void *f,ogg_int64_t off,int whence)
+	{ return cdStreamSeek(f,off,whence); }
+static size_t ov_cdStreamRead(void *buf, size_t sz, size_t n, void *f)
+	{ return cdStreamRead(buf,sz,n,f); }
+static int ov_cdStreamClose(void *f)
+	{ return cdStreamClose(f); }
+static long ov_cdStreamTell(void *f)
+	{ return cdStreamTell(f); }
+static ov_callbacks cb = { ov_cdStreamRead, ov_seek64_wrap, ov_cdStreamClose, ov_cdStreamTell };
 
 #ifdef DISABLE_MANY_OGG_OPEN_FILES
 static void ogg_free(int i)


### PR DESCRIPTION
Coming from https://github.com/libretro/Genesis-Plus-GX/pull/382

Not sure but it seems the libretro VFS implementation/stuff breaks OGG playback in some Libretro platforms (mostly GameCube/Wii/Wii U), which probably overlays the stdio stuff from libc, causing conflicts.

Replace the old `ov_callbacks` logic with a more robust one to be able to load OGG files on both GX standalone and libretro port.
Tested and working as intended on both ports.

Also disables multiple OGG files open at once in the libretro cores for GC, Wii, and Wii U, as it could also cause OGG playback issues.

Thanks to @irixxxx for helping with this fix.