### PR TITLE
vdp_ctrl.h: declare sat/vram/cram/vsram with the alignment they are defined with

### DIFF
--- a/core/vdp_ctrl.h
+++ b/core/vdp_ctrl.h
@@ -44,10 +44,14 @@
 
 /* VDP context */
 extern uint8 reg[0x20];
-extern uint8 sat[0x400];
-extern uint8 vram[0x10000];
-extern uint8 cram[0x80];
-extern uint8 vsram[0x80];
+/* These four are defined with ALIGNED_(4) in vdp_ctrl.c. Repeating the
+   attribute here keeps declaration and definition in agreement: a TU that
+   only sees the extern assumes the type's preferred alignment (16 for an
+   array this size) and may vectorize a copy with an aligned load. */
+extern uint8 ALIGNED_(4) sat[0x400];
+extern uint8 ALIGNED_(4) vram[0x10000];
+extern uint8 ALIGNED_(4) cram[0x80];
+extern uint8 ALIGNED_(4) vsram[0x80];
 extern uint8 hint_pending;
 extern uint8 vint_pending;
 extern uint16 status;


### PR DESCRIPTION
`core/vdp_ctrl.c` defines four VDP buffers with `ALIGNED_(4)`:

```c
uint8 ALIGNED_(4) sat[0x400];
uint8 ALIGNED_(4) vram[0x10000];
uint8 ALIGNED_(4) cram[0x80];
uint8 ALIGNED_(4) vsram[0x80];
```

but `core/vdp_ctrl.h` declares them as plain externs. Neither file is wrong on its own; together they are. A translation unit that only sees the declaration assumes the type's *preferred* alignment — 16 for arrays this size on x86-64 — and is free to vectorize a copy with an aligned load.

## How it showed up

In a downstream fork, a function in another TU does `memcpy(dst, cram, sizeof(cram))`. At `-O2` clang turned that into:

```
movq   0x17156b(%rip), %rax    # <.refptr.cram>
movaps 0x70(%rax), %xmm0
```

`movaps` requires 16-byte alignment, and `cram` lands at `...0228` — 8-byte aligned. The process died with an access violation on the very first call. Windows reports the SSE alignment fault as a read from `0xffffffffffffffff`, which sends you looking for a bad pointer instead of a bad alignment.

It only happens at `-O2`. `-O0` does not vectorize, so debug builds look perfectly healthy — which is what made it take a while to find.

The call site is fork-specific, but the mismatch is not: any TU that copies one of these four arrays wholesale is entitled to do the same thing, and the compiler is within its rights.

## The change

Repeat the attribute on the declarations so both sides agree. This does **not** change the binary layout — the definitions keep `ALIGNED_(4)` — which is why it's preferred here over raising them to 16. `reg[0x20]` is deliberately left alone: it carries no attribute on either side, so both already agree.

## Verified

Built at `-O2` with llvm-mingw with the change applied. (Note for anyone reproducing on that toolchain: the link step needs `--version-script` dropped, since `lld` doesn't accept it — unrelated to this change.)
